### PR TITLE
Add "req-route" to access logger

### DIFF
--- a/services/backend/oodikone2-backend/src/middleware/accesslogger.js
+++ b/services/backend/oodikone2-backend/src/middleware/accesslogger.js
@@ -10,6 +10,7 @@ const accessLogger = morgan((tokens, req, res) => {
   const fields = ['method', 'url', 'status', 'response-time', 'remote-addr', 'remote-user', 'user-agent', 'referrer']
   const meta = req.decodedToken
   fields.forEach(field => (meta[field] = tokens[field](req, res)))
+  meta['req-route'] = req.route.path
 
   const message = [
     req.decodedToken.name,


### PR DESCRIPTION
The req-route field grabs req.route.path, which will let us group response
times by the actual route instead of by a specific URL.