### PR TITLE
Pass event label as tag instead of field

### DIFF
--- a/services/backend/oodikone2-backend/src/routes/tsaAnalytics.js
+++ b/services/backend/oodikone2-backend/src/routes/tsaAnalytics.js
@@ -5,8 +5,8 @@ const tsaService = require('../services/tsaService')
 router.post('/event', (req, res) => {
   const { group, name, label, value } = req.body
 
-  if (!group || !name) {
-    return res.status(400).json({ error: 'group and name are required' })
+  if (!group || !name || !value) {
+    return res.status(400).json({ error: 'group, name and value are required' })
   }
 
   // don't await here because frontend doesn't care if it succeeds

--- a/services/backend/oodikone2-backend/src/services/tsaService/index.js
+++ b/services/backend/oodikone2-backend/src/services/tsaService/index.js
@@ -48,17 +48,24 @@ const sendTsaEvent = (userId, { group, name, label, value }) => {
     return Promise.resolve()
   }
 
-  let fields = {}
-  if (label) fields.eventLabel = label
-  if (value) fields.eventValue = value
+  if (!value) {
+    throw new Error('Value is required')
+  }
 
   // note: influxdb line protocol supports multiple events per write
   // so if we need that in the future, it can be implemented instead of
   // looping
   return write({
     measurement: 'oodikone_tsa_event',
-    tags: { userId, eventGroup: group, eventName: name },
-    fields: fields,
+    tags: {
+      userId,
+      eventGroup: group,
+      eventName: name,
+      eventLabel: label
+    },
+    fields: {
+      eventValue: value
+    },
     timestamp: new Date()
   })
 }

--- a/services/oodikone2-frontend/src/common/tsa.jsx
+++ b/services/oodikone2-frontend/src/common/tsa.jsx
@@ -38,7 +38,7 @@ const TSA = {
  *      return
  *    }
  *
- *     TSA.sendEvent({ group: 'Student Usage', name: 'student data viewed', label: props.studentId })
+ *     TSA.sendEvent({ group: 'Student Usage', name: 'student data viewed', label: props.studentId, value: 1 })
  *   }, [props.studentId])
  * })
  * export default withStudentDataTsa(StudentData)

--- a/services/oodikone2-frontend/src/components/PopulationSearchForm/index.jsx
+++ b/services/oodikone2-frontend/src/components/PopulationSearchForm/index.jsx
@@ -140,7 +140,12 @@ const PopulationSearchForm = props => {
     const query = parseQueryFromUrl()
 
     if (query.studyRights && query.studyRights.programme) {
-      TSA.sendEvent({ group: 'Programme Usage', name: 'populations query', label: query.studyRights.programme })
+      TSA.sendEvent({
+        group: 'Programme Usage',
+        name: 'populations query',
+        label: query.studyRights.programme,
+        value: 1
+      })
     }
 
     if (!checkPreviousQuery(query, previousQuery)) {

--- a/services/oodikone2-frontend/src/components/StudyProgramme/index.jsx
+++ b/services/oodikone2-frontend/src/components/StudyProgramme/index.jsx
@@ -169,7 +169,7 @@ const withPopulationUsageTsa = bakeTsaHooks(props => {
       return
     }
 
-    TSA.sendEvent({ group: 'Programme Usage', name: 'study programme overview', label: studyProgrammeId })
+    TSA.sendEvent({ group: 'Programme Usage', name: 'study programme overview', label: studyProgrammeId, value: 1 })
   }, [studyProgrammeId])
 })
 


### PR DESCRIPTION
So InfluxDB doesn't support GROUP BYs on fields. If we want to GROUP BY
something, it needs to be sent as a tag. This, however, might be a problem
in the future because if there's a lot of random stuff in tags, that will
increase the series cardinality a lot which is not good for performance:

https://docs.influxdata.com/influxdb/v1.7/concepts/glossary/#series-cardinality

Because InfluxDB requires some field to be sent along with the tags, we
now send 1 as the value for these view events. Maybe we can pretend it
represents a single view.