### PR TITLE
Fix duplicate transfers table rows, fix CI for this decade

### DIFF
--- a/cypress/integration/Population_statistics.js
+++ b/cypress/integration/Population_statistics.js
@@ -58,7 +58,9 @@ describe('Population Statistics tests', () => {
 
     cy.get("@enrollmentSelect").its(`${[0]}.value`).then((beforeVal) => {
       cy.get("@enrollmentSelect").click()
-      cy.get("table").contains("2014-2015").click()
+      // go back to 2010-2019
+      cy.get(".yearSelectInput .rdtPrev").click()
+      cy.get(".yearSelectInput table").contains("2014-2015").click()
       cy.get("@enrollmentSelect").should('not.have.value', beforeVal)
     })
 

--- a/services/backend/shared/migrations/20200101_00_fix_transfers_duplicates.js
+++ b/services/backend/shared/migrations/20200101_00_fix_transfers_duplicates.js
@@ -1,0 +1,27 @@
+module.exports = {
+  up: async queryInterface => {
+    await queryInterface.sequelize.query(
+      `DELETE
+            FROM transfers a
+                USING transfers b
+            WHERE
+                a.id > b.id
+                AND a.transferdate = b.transferdate
+                AND a.studentnumber = b.studentnumber
+                AND a.studyrightid = b.studyrightid
+                AND a.sourcecode = b.sourcecode
+                AND a.targetcode = b.targetcode`,
+      {
+        raw: true
+      }
+    )
+    await queryInterface.addIndex(
+      'transfers',
+      ['studyrightid', 'sourcecode', 'targetcode', 'transferdate', 'studentnumber'],
+      {
+        unique: true
+      }
+    )
+  },
+  down: async () => {}
+}

--- a/services/backend/shared/models/index.js
+++ b/services/backend/shared/models/index.js
@@ -383,6 +383,10 @@ const Transfers = sequelize.define(
   {
     indexes: [
       {
+        fields: ['studyrightid', 'sourcecode', 'targetcode', 'transferdate', 'studentnumber'],
+        unique: true
+      },
+      {
         fields: ['studentnumber'],
         name: 'transfers_studentnumber'
       }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
@@ -289,7 +289,7 @@ class SingleCourseStats extends Component {
   }
 
   render() {
-    const { programmes, maxYearsToCreatePopulationFrom } = this.props
+    const { programmes, maxYearsToCreatePopulationFrom, stats } = this.props
     const { primary, comparison, fromYear, toYear } = this.state
     const statistics = this.filteredProgrammeStatistics()
     const { filteredYears } = this.filteredYearsAndSemesters()
@@ -301,6 +301,8 @@ class SingleCourseStats extends Component {
         return { ...e, students: [...students], size: students.size }
       })
       .filter(e => e.size > 0)
+
+    if (stats.statistics.length < 1) return <Segment>No data for selected course</Segment>
 
     return (
       <div>

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseTab/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseTab/index.jsx
@@ -12,11 +12,7 @@ class SingleCourseTab extends Component {
 
   getStats = () => {
     const { stats } = this.props
-    const statistics = Object.values(stats)
-    let { selected } = this.state
-    if (!selected && statistics.length > 0) {
-      selected = statistics[0].coursecode
-    }
+    const { selected } = this.state
     return {
       selected,
       selectedStatistic: stats[selected]
@@ -61,11 +57,7 @@ class SingleCourseTab extends Component {
 SingleCourseTab.propTypes = {
   stats: shape({}).isRequired,
   courses: arrayOf(shape({})).isRequired,
-  selected: oneOfType([number, string])
-}
-
-SingleCourseTab.defaultProps = {
-  selected: undefined
+  selected: oneOfType([number, string]).isRequired
 }
 
 const mapStateToProps = state => ({

--- a/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Header, Segment, Tab } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
-import { bool, shape, func } from 'prop-types'
+import { bool, shape, func, string } from 'prop-types'
 import './courseStatistics.css'
 import SearchForm from './SearchForm'
 import SingleCourseTab from './SingleCourseTab'
@@ -20,16 +20,16 @@ const MENU = {
 }
 
 const CourseStatistics = props => {
-  const { singleCourseStats, clearCourseStats, history, statsIsEmpty, loading } = props
+  const { singleCourseStats, clearCourseStats, history, statsIsEmpty, loading, initCourseCode } = props
 
   const [activeIndex, setActiveIndex] = useState(0)
-  const [selected, setSelected] = useState(undefined)
+  const [selected, setSelected] = useState(initCourseCode)
   const { onProgress, progress } = useProgress(loading)
   useTitle('Course statistics')
 
   useEffect(() => {
     if (statsIsEmpty) {
-      setSelected(undefined)
+      setSelected(initCourseCode)
       setActiveIndex(0)
     }
   }, [statsIsEmpty])
@@ -47,7 +47,7 @@ const CourseStatistics = props => {
       },
       {
         menuItem: MENU.COURSE,
-        render: () => <SingleCourseTab selected={selected} />
+        render: () => <SingleCourseTab selected={selected || initCourseCode} />
       },
       {
         menuItem: MENU.FACULTY,
@@ -104,7 +104,8 @@ CourseStatistics.propTypes = {
   singleCourseStats: bool.isRequired,
   history: shape({}).isRequired,
   clearCourseStats: func.isRequired,
-  loading: bool.isRequired
+  loading: bool.isRequired,
+  initCourseCode: string.isRequired
 }
 
 const mapStateToProps = ({ courseStats }) => {
@@ -114,7 +115,8 @@ const mapStateToProps = ({ courseStats }) => {
     error: courseStats.error,
     statsIsEmpty: courses.length === 0,
     singleCourseStats: courses.length === 1,
-    loading: courseStats.pending
+    loading: courseStats.pending,
+    initCourseCode: courses[0] || ''
   }
 }
 

--- a/services/oodikone2-frontend/src/components/PopulationCourses/index.jsx
+++ b/services/oodikone2-frontend/src/components/PopulationCourses/index.jsx
@@ -34,6 +34,7 @@ const PopulationCourses = ({
     gpc({
       ...selectedPopulationCourses.query,
       uuid: uuidv4(),
+      studyRights: [query.studyRights.programme],
       selectedStudents,
       selectedStudentsByYear,
       year: query.year,


### PR DESCRIPTION
The bulkcreate in updater_writer has "ignoreDuplicates", but the
transfers table was missing an unique index, meaning that the updater
was writing duplicate rows on every run. At this point, there were about
20 duplicates per row.

Fixed by deleting duplicate rows and then adding an unique index.