### PR TITLE
Hide stats for courseStats-users if 5 or less students on a yearly level

### DIFF
--- a/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
+++ b/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
@@ -196,6 +196,7 @@ class CourseYearlyStatsCounter {
         // totals cannot be calculated
         this.obfuscated = true
         const obfuscatedStats = {
+          obfuscated: true,
           code: rest.code,
           name: rest.name,
           coursecode: rest.coursecode,

--- a/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
+++ b/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
@@ -192,7 +192,7 @@ class CourseYearlyStatsCounter {
         students: this.parseStudentStatistics(students)
       }
       if (anonymizationSalt && normalStats.students.studentnumbers.length < 6) {
-        // indicate to the front that some of the data has been obfuscated and therefore 
+        // indicate to the front that some of the data has been obfuscated and therefore
         // totals cannot be calculated
         this.obfuscated = true
         let gradeSpread = {}
@@ -210,7 +210,7 @@ class CourseYearlyStatsCounter {
               failed: [],
               passed: []
             },
-            grades: gradeSpread,
+            grades: gradeSpread
           },
           yearcode: rest.yearcode,
           students: {

--- a/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
+++ b/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
@@ -174,7 +174,7 @@ class CourseYearlyStatsCounter {
     if (anonymizationSalt) {
       this.programmes = {
         '000000': {
-          name: { en: '', fi: '', sv: ''},
+          name: { en: '', fi: '', sv: '' },
           credits: {},
           passed: {},
           students: {}
@@ -195,6 +195,11 @@ class CourseYearlyStatsCounter {
         // indicate to the front that some of the data has been obfuscated and therefore 
         // totals cannot be calculated
         this.obfuscated = true
+        let gradeSpread = {}
+        for (const grade in normalStats.students.grades) {
+          gradeSpread[grade] = []
+        }
+
         const obfuscatedStats = {
           obfuscated: true,
           code: rest.code,
@@ -205,12 +210,17 @@ class CourseYearlyStatsCounter {
               failed: [],
               passed: []
             },
-            grades: {},
+            grades: gradeSpread,
           },
           yearcode: rest.yearcode,
           students: {
-            classes: {},
-            grades: {},
+            classes: {
+              failedFirst: [],
+              failedRetry: [],
+              passedFirst: [],
+              passedRetry: []
+            },
+            grades: gradeSpread,
             studentnumbers: []
           }
         }

--- a/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
+++ b/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
@@ -172,28 +172,14 @@ class CourseYearlyStatsCounter {
 
   parseProgrammeStatistics(anonymizationSalt) {
     if (anonymizationSalt) {
-      this.programmes = Object.values(this.programmes).map(({ students, passed, credits, name }) => {
-        let obfuscatedStudents = {}
-        let obfuscatedPassed = {}
-        let obfuscatedCredits = {}
-        for (const [yearcode, studentsOfTheYear] of Object.entries(students)) {
-          if (studentsOfTheYear.length < 6) {
-            obfuscatedStudents[yearcode] = -1
-            obfuscatedPassed[yearcode] = -1
-            obfuscatedCredits[yearcode] = -1
-          } else {
-            obfuscatedStudents[yearcode] = studentsOfTheYear
-            obfuscatedPassed[yearcode] = passed[yearcode]
-            obfuscatedCredits[yearcode] = credits[yearcode]
-          }
+      this.programmes = {
+        '000000': {
+          name: { en: '', fi: '', sv: ''},
+          credits: {},
+          passed: {},
+          students: {}
         }
-        return {
-          name,
-          credits: obfuscatedCredits,
-          passed: obfuscatedPassed,
-          students: obfuscatedStudents
-        }
-      })
+      }
     }
 
     return this.programmes
@@ -213,9 +199,19 @@ class CourseYearlyStatsCounter {
           code: rest.code,
           name: rest.name,
           coursecode: rest.coursecode,
-          attempts: -1,
+          attempts: {
+            classes: {
+              failed: [],
+              passed: []
+            },
+            grades: {},
+          },
           yearcode: rest.yearcode,
-          students: -1
+          students: {
+            classes: {},
+            grades: {},
+            studentnumbers: []
+          }
         }
         return obfuscatedStats
       }
@@ -227,23 +223,15 @@ class CourseYearlyStatsCounter {
 
   parseFacultyStatistics(anonymizationSalt) {
     if (anonymizationSalt) {
-      this.facultyStats = Object.values(this.facultyStats).map(({ allStudents, ...rest }) => {
-        const normalStats = {
-          ...rest,
-          allStudents
+      this.facultyStats = [
+        {
+          year: 'NA',
+          allCredits: 0,
+          allPassed: [],
+          allStudents: [],
+          faculties: {}
         }
-        if (allStudents.length < 6) {
-          const obfuscatedStats = {
-            year: rest.year,
-            allCredits: -1,
-            allPassed: -1,
-            allStudents: -1,
-            faculties: -1
-          }
-          return obfuscatedStats
-        }
-        return normalStats
-      })
+      ]
     }
     return this.facultyStats
   }

--- a/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
+++ b/services/backend/oodikone2-backend/src/services/course_yearly_stats_counter.js
@@ -10,6 +10,7 @@ class CourseYearlyStatsCounter {
     this.groups = {}
     this.programmes = {}
     this.facultyStats = {}
+    this.obfuscated = false
     this.history = {
       passed: new Set(),
       failed: new Set(),
@@ -205,6 +206,9 @@ class CourseYearlyStatsCounter {
         students: this.parseStudentStatistics(students)
       }
       if (anonymizationSalt && normalStats.students.studentnumbers.length < 6) {
+        // indicate to the front that some of the data has been obfuscated and therefore 
+        // totals cannot be calculated
+        this.obfuscated = true
         const obfuscatedStats = {
           code: rest.code,
           name: rest.name,
@@ -248,7 +252,8 @@ class CourseYearlyStatsCounter {
     return {
       programmes: this.parseProgrammeStatistics(anonymizationSalt),
       statistics: this.parseGroupStatistics(anonymizationSalt),
-      facultyStats: this.parseFacultyStatistics(anonymizationSalt)
+      facultyStats: this.parseFacultyStatistics(anonymizationSalt),
+      obfuscated: this.obfuscated
     }
   }
 }

--- a/services/backend/oodikone2-backend/src/services/courses.js
+++ b/services/backend/oodikone2-backend/src/services/courses.js
@@ -512,7 +512,7 @@ const yearlyStatsOfNew = async (coursecode, separate, unifyOpenUniCourses, anony
     counter.markCreditToGroup(studentnumber, passed, grade, groupcode, groupname, coursecode, yearcode)
     counter.markCreditToHistory(studentnumber, passed)
   }
-  const statistics = counter.getFinalStatistics()
+  const statistics = counter.getFinalStatistics(anonymizationSalt)
   return {
     ...statistics,
     coursecode,

--- a/services/backend/oodikone2-backend/src/sisoodi_diff/populations.js
+++ b/services/backend/oodikone2-backend/src/sisoodi_diff/populations.js
@@ -69,7 +69,8 @@ const ignores = {
   },
   KH60_001: {
     2017: {
-      oodi: [ // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
+      oodi: [
+        // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
         '013299358',
         '014720169',
         '014711262',
@@ -78,33 +79,17 @@ const ignores = {
         '014659133'
       ]
     },
-    2018:{ // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
-      oodi: [
-        '014726105',
-        '014708699',
-        '014732623',
-        '014728983',
-        '014323074',
-        '014624977',
-      ]
+    2018: {
+      // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
+      oodi: ['014726105', '014708699', '014732623', '014728983', '014323074', '014624977']
     },
-    2019:{ // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
-      oodi: [
-        '014366086',
-        '014731909',
-        '014734511',
-      ]
+    2019: {
+      // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
+      oodi: ['014366086', '014731909', '014734511']
     },
-    2020:{ // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
-      oodi: [
-        '013466013',
-        '014590027',
-        '014340963',
-        '014179998',
-        '013743299',
-        '013758239',
-        '014590807',
-      ]
+    2020: {
+      // varhaiskasvatus https://github.com/UniversityOfHelsinkiCS/oodikone/issues/2738
+      oodi: ['013466013', '014590027', '014340963', '014179998', '013743299', '013758239', '014590807']
     }
   },
   // there are many inconsistencies in masters, so they're grouped by the reason, not

--- a/services/oodikone2-frontend/src/components/AccessDenied/index.jsx
+++ b/services/oodikone2-frontend/src/components/AccessDenied/index.jsx
@@ -24,7 +24,9 @@ const names = [
   'cxcorp',
   'ajhaa',
   'joonashak',
-  'vaahtokarkki'
+  'vaahtokarkki',
+  'otahontas',
+  'saarasat'
 ]
 
 const dummyData = names.map(name => ({

--- a/services/oodikone2-frontend/src/components/CourseStatistics/CumulativeTable/foldableRow.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/CumulativeTable/foldableRow.jsx
@@ -23,10 +23,15 @@ class FoldableRow extends Component {
     const hasRealisations = realisations.length && realisations.length > 0
     const showCourseRealisations = hasRealisations && isUnfolded
 
-    const getCell = content => <Table.Cell content={content} />
+    const getCell = (content, obfuscated) => (
+      <Table.Cell
+        style={{ color: obfuscated && 'gray' }}
+        content={obfuscated ? '5 or less students' : content}
+      />
+    )
 
     const getRow = (rowId, rowData, isMainRow = true) => {
-      const { passed, failed, passrate, realisation } = rowData
+      const { passed, failed, passrate, realisation, obfuscated } = rowData
       const showFoldIcon = isMainRow && hasRealisations
       return (
         <Table.Row key={rowId} className={!isMainRow ? 'subRow' : ''}>
@@ -46,12 +51,13 @@ class FoldableRow extends Component {
                 realisation
               )
             }
+            style={{ color: obfuscated && 'gray' }}
             className={isMainRow ? 'courseNameCell' : 'courseRealisationCell'}
             onClick={() => onClickFn(id)}
           />
-          {getCell(passed)}
-          {getCell(failed)}
-          {getCell(`${passrate || 0} %`)}
+          {getCell(passed, obfuscated)}
+          {getCell(failed, obfuscated)}
+          {getCell(`${passrate || 0} %`, obfuscated)}
         </Table.Row>
       )
     }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/CumulativeTable/foldableRow.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/CumulativeTable/foldableRow.jsx
@@ -24,10 +24,7 @@ class FoldableRow extends Component {
     const showCourseRealisations = hasRealisations && isUnfolded
 
     const getCell = (content, obfuscated) => (
-      <Table.Cell
-        style={{ color: obfuscated && 'gray' }}
-        content={obfuscated ? '5 or less students' : content}
-      />
+      <Table.Cell style={{ color: obfuscated && 'gray' }} content={obfuscated ? '5 or less students' : content} />
     )
 
     const getRow = (rowId, rowData, isMainRow = true) => {

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
@@ -56,17 +56,17 @@ const CumulativeTable = ({ stats, name, alternatives, separate }) => {
             getRowVal: s => Object.values(s.students.grades).reduce((a, b) => a + b, 0),
             cellProps: { width: 4 }
           },
-          { key: 'FAILED', title: 'Failed', getRowVal: s => s.cumulative.categories.failed, cellProps: { width: 4 } },
+          {
+            key: 'FAILED',
+            title: 'Failed',
+            getRowVal: s => s.cumulative.categories.failed,
+            cellProps: { width: 4 }
+          },
           {
             key: 'PASSRATE',
             title: 'Pass rate',
-            getRowVal: s =>
-              s.cumulative.categories.passed / (s.cumulative.categories.failed + s.cumulative.categories.passed),
-            getRowContent: stat =>
-              `${Number(
-                (100 * stat.cumulative.categories.passed) /
-                  (stat.cumulative.categories.failed + stat.cumulative.categories.passed) || 0
-              ).toFixed(2)} %`,
+            getRowVal: s => s.cumulative.categories.passRate,
+            getRowContent: s => `${Number(s.cumulative.categories.passRate || 0).toFixed(2)} %`,
             cellProps: { width: 4 }
           }
         ]}

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
@@ -39,7 +39,7 @@ const CumulativeTable = ({ stats, name, alternatives, separate, populationsShoul
               s.code !== 9999 ? (
                 <div>
                   {s.name}
-                  {(s.name !== 'Total' && populationsShouldBeVisible) ? (
+                  {s.name !== 'Total' && populationsShouldBeVisible ? (
                     <Item as={Link} to={showPopulation(s.code, s.name, s)}>
                       <Icon name="level up alternate" />
                     </Item>
@@ -55,22 +55,23 @@ const CumulativeTable = ({ stats, name, alternatives, separate, populationsShoul
             key: 'PASSED',
             title: 'Passed',
             // Backend returns duplicates in `s.cumulative` -> use `s.students`.
-            getRowVal: s => s.rowObfuscated ? '5 or less students' : Object.values(s.students.grades).reduce((a, b) => a + b, 0),
+            getRowVal: s =>
+              s.rowObfuscated ? '5 or less students' : Object.values(s.students.grades).reduce((a, b) => a + b, 0),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           },
           {
             key: 'FAILED',
             title: 'Failed',
-            getRowVal: s => s.rowObfuscated ? '5 or less students': s.cumulative.categories.failed,
+            getRowVal: s => (s.rowObfuscated ? '5 or less students' : s.cumulative.categories.failed),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           },
           {
             key: 'PASSRATE',
             title: 'Pass rate',
-            getRowVal: s => s.rowObfuscated ? 'NA' : s.cumulative.passRate,
-            getRowContent: s => s.rowObfuscated ? 'NA' : `${Number(s.cumulative.passRate || 0).toFixed(2)} %`,
+            getRowVal: s => (s.rowObfuscated ? 'NA' : s.cumulative.passRate),
+            getRowContent: s => (s.rowObfuscated ? 'NA' : `${Number(s.cumulative.passRate || 0).toFixed(2)} %`),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           }
@@ -86,7 +87,7 @@ CumulativeTable.propTypes = {
   name: oneOfType([number, string]).isRequired,
   alternatives: arrayOf(string).isRequired,
   separate: bool,
-  populationsShouldBeVisible: bool,
+  populationsShouldBeVisible: bool.isRequired
 }
 
 CumulativeTable.defaultProps = {

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
@@ -47,26 +47,30 @@ const CumulativeTable = ({ stats, name, alternatives, separate }) => {
               ) : (
                 <div>{s.name}</div>
               ),
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 4 }
           },
           {
             key: 'PASSED',
             title: 'Passed',
             // Backend returns duplicates in `s.cumulative` -> use `s.students`.
-            getRowVal: s => Object.values(s.students.grades).reduce((a, b) => a + b, 0),
+            getRowVal: s => s.obfuscated ? '5 or less students' : Object.values(s.students.grades).reduce((a, b) => a + b, 0),
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 4 }
           },
           {
             key: 'FAILED',
             title: 'Failed',
-            getRowVal: s => s.cumulative.categories.failed,
+            getRowVal: s => s.obfuscated ? '5 or less students': s.cumulative.categories.failed,
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 4 }
           },
           {
             key: 'PASSRATE',
             title: 'Pass rate',
-            getRowVal: s => s.cumulative.categories.passRate,
-            getRowContent: s => `${Number(s.cumulative.categories.passRate || 0).toFixed(2)} %`,
+            getRowVal: s => s.obfuscated ? 'NA' : s.cumulative.passRate,
+            getRowContent: s => s.obfuscated ? 'NA' : `${Number(s.cumulative.passRate || 0).toFixed(2)} %`,
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 4 }
           }
         ]}

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
@@ -8,7 +8,7 @@ import { shape, string, number, oneOfType, arrayOf, bool } from 'prop-types'
 import SortableTable from '../../../../SortableTable'
 import { defineCellColor } from '../util'
 
-const CumulativeTable = ({ stats, name, alternatives, separate }) => {
+const CumulativeTable = ({ stats, name, alternatives, separate, populationsShouldBeVisible }) => {
   const showPopulation = (yearcode, years) => {
     const queryObject = {
       from: yearcode,
@@ -39,7 +39,7 @@ const CumulativeTable = ({ stats, name, alternatives, separate }) => {
               s.code !== 9999 ? (
                 <div>
                   {s.name}
-                  {s.name !== 'Total' ? (
+                  {(s.name !== 'Total' && populationsShouldBeVisible) ? (
                     <Item as={Link} to={showPopulation(s.code, s.name, s)}>
                       <Icon name="level up alternate" />
                     </Item>
@@ -55,22 +55,22 @@ const CumulativeTable = ({ stats, name, alternatives, separate }) => {
             key: 'PASSED',
             title: 'Passed',
             // Backend returns duplicates in `s.cumulative` -> use `s.students`.
-            getRowVal: s => s.obfuscated ? '5 or less students' : Object.values(s.students.grades).reduce((a, b) => a + b, 0),
+            getRowVal: s => s.rowObfuscated ? '5 or less students' : Object.values(s.students.grades).reduce((a, b) => a + b, 0),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           },
           {
             key: 'FAILED',
             title: 'Failed',
-            getRowVal: s => s.obfuscated ? '5 or less students': s.cumulative.categories.failed,
+            getRowVal: s => s.rowObfuscated ? '5 or less students': s.cumulative.categories.failed,
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           },
           {
             key: 'PASSRATE',
             title: 'Pass rate',
-            getRowVal: s => s.obfuscated ? 'NA' : s.cumulative.passRate,
-            getRowContent: s => s.obfuscated ? 'NA' : `${Number(s.cumulative.passRate || 0).toFixed(2)} %`,
+            getRowVal: s => s.rowObfuscated ? 'NA' : s.cumulative.passRate,
+            getRowContent: s => s.rowObfuscated ? 'NA' : `${Number(s.cumulative.passRate || 0).toFixed(2)} %`,
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           }
@@ -85,7 +85,8 @@ CumulativeTable.propTypes = {
   stats: arrayOf(shape({})).isRequired,
   name: oneOfType([number, string]).isRequired,
   alternatives: arrayOf(string).isRequired,
-  separate: bool
+  separate: bool,
+  populationsShouldBeVisible: bool,
 }
 
 CumulativeTable.defaultProps = {

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/cumulative.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import { uniq } from 'lodash'
 import { shape, string, number, oneOfType, arrayOf, bool } from 'prop-types'
 import SortableTable from '../../../../SortableTable'
+import { defineCellColor } from '../util'
 
 const CumulativeTable = ({ stats, name, alternatives, separate }) => {
   const showPopulation = (yearcode, years) => {
@@ -47,7 +48,7 @@ const CumulativeTable = ({ stats, name, alternatives, separate }) => {
               ) : (
                 <div>{s.name}</div>
               ),
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           },
           {
@@ -55,14 +56,14 @@ const CumulativeTable = ({ stats, name, alternatives, separate }) => {
             title: 'Passed',
             // Backend returns duplicates in `s.cumulative` -> use `s.students`.
             getRowVal: s => s.obfuscated ? '5 or less students' : Object.values(s.students.grades).reduce((a, b) => a + b, 0),
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           },
           {
             key: 'FAILED',
             title: 'Failed',
             getRowVal: s => s.obfuscated ? '5 or less students': s.cumulative.categories.failed,
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           },
           {
@@ -70,7 +71,7 @@ const CumulativeTable = ({ stats, name, alternatives, separate }) => {
             title: 'Pass rate',
             getRowVal: s => s.obfuscated ? 'NA' : s.cumulative.passRate,
             getRowContent: s => s.obfuscated ? 'NA' : `${Number(s.cumulative.passRate || 0).toFixed(2)} %`,
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 4 }
           }
         ]}

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/grades.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/grades.jsx
@@ -21,18 +21,37 @@ const getTableData = (stats, isGradeSeries, isRelative) =>
       name,
       code,
       cumulative: { grades },
-      coursecode
+      coursecode,
+      obfuscated
     } = stat
 
-    const spread = isGradeSeries ? getGradeSpread([grades], isRelative) : getThesisGradeSpread([grades], isRelative)
+    if (obfuscated) {
+      return {
+        name,
+        code,
+        coursecode,
+        attempts: '5 or less students',
+        0: ['NA'],
+        1: ['NA'],
+        2: ['NA'],
+        3: ['NA'],
+        4: ['NA'],
+        5: ['NA'],
+        HT: ['NA'],
+        TT: ['NA'],
+        'Hyv.': ['NA']
+      }
+    }
 
     const attempts = Object.values(grades).reduce((cur, acc) => acc + cur, 0)
+    const gradeSpread = isGradeSeries ? getGradeSpread([grades], isRelative) : getThesisGradeSpread([grades], isRelative)
+
     return {
       name,
       code,
       coursecode,
       attempts,
-      ...spread
+      ...gradeSpread
     }
   })
 

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/grades.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/grades.jsx
@@ -6,14 +6,20 @@ import { connect } from 'react-redux'
 import { Header, Icon, Item } from 'semantic-ui-react'
 import { uniq } from 'lodash'
 import SortableTable from '../../../../SortableTable'
-import { getGradeSpread, getThesisGradeSpread, isThesisGrades, THESIS_GRADE_KEYS } from '../util'
+import {
+  defineCellColor,
+  getGradeSpread,
+  getThesisGradeSpread,
+  isThesisGrades,
+  THESIS_GRADE_KEYS
+} from '../util'
 
 const getSortableColumn = (key, title, getRowVal, getRowContent) => ({
   key,
   title,
   getRowVal,
   getRowContent,
-  getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+  getCellProps: s => defineCellColor(s),
 })
 
 const getTableData = (stats, notThesisGrades, isRelative) =>

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/grades.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/grades.jsx
@@ -6,20 +6,14 @@ import { connect } from 'react-redux'
 import { Header, Icon, Item } from 'semantic-ui-react'
 import { uniq } from 'lodash'
 import SortableTable from '../../../../SortableTable'
-import {
-  defineCellColor,
-  getGradeSpread,
-  getThesisGradeSpread,
-  isThesisGrades,
-  THESIS_GRADE_KEYS
-} from '../util'
+import { defineCellColor, getGradeSpread, getThesisGradeSpread, isThesisGrades, THESIS_GRADE_KEYS } from '../util'
 
 const getSortableColumn = (key, title, getRowVal, getRowContent) => ({
   key,
   title,
   getRowVal,
   getRowContent,
-  getCellProps: s => defineCellColor(s),
+  getCellProps: s => defineCellColor(s)
 })
 
 const getTableData = (stats, notThesisGrades, isRelative) =>
@@ -33,7 +27,9 @@ const getTableData = (stats, notThesisGrades, isRelative) =>
     } = stat
 
     const attempts = Object.values(grades).reduce((cur, acc) => acc + cur, 0)
-    const gradeSpread = notThesisGrades ? getGradeSpread([grades], isRelative) : getThesisGradeSpread([grades], isRelative)
+    const gradeSpread = notThesisGrades
+      ? getGradeSpread([grades], isRelative)
+      : getThesisGradeSpread([grades], isRelative)
 
     return {
       name,
@@ -49,18 +45,23 @@ const includesHTOrTT = stats =>
   stats.some(({ cumulative }) => ['HT', 'TT'].some(grade => Object.keys(cumulative.grades).includes(grade)))
 
 const getGradeColumns = (notThesisGrades, addHTAndTT) => {
-  if (!notThesisGrades) return THESIS_GRADE_KEYS.map(k => getSortableColumn(k, k, s => s.rowObfuscated ? 'NA' : s[k]))
+  if (!notThesisGrades) return THESIS_GRADE_KEYS.map(k => getSortableColumn(k, k, s => (s.rowObfuscated ? 'NA' : s[k])))
   const columns = [
-    getSortableColumn('0', '0', s => s.rowObfuscated ? 'NA' : s['0']),
-    getSortableColumn('1', '1', s => s.rowObfuscated ? 'NA' : s['1']),
-    getSortableColumn('2', '2', s => s.rowObfuscated ? 'NA' : s['2']),
-    getSortableColumn('3', '3', s => s.rowObfuscated ? 'NA' : s['3']),
-    getSortableColumn('4', '4', s => s.rowObfuscated ? 'NA' : s['4']),
-    getSortableColumn('5', '5', s => s.rowObfuscated ? 'NA' : s['5']),
-    getSortableColumn('OTHER_PASSED', 'Other passed', s => s.rowObfuscated ? 'NA' : s['Hyv.'])
+    getSortableColumn('0', '0', s => (s.rowObfuscated ? 'NA' : s['0'])),
+    getSortableColumn('1', '1', s => (s.rowObfuscated ? 'NA' : s['1'])),
+    getSortableColumn('2', '2', s => (s.rowObfuscated ? 'NA' : s['2'])),
+    getSortableColumn('3', '3', s => (s.rowObfuscated ? 'NA' : s['3'])),
+    getSortableColumn('4', '4', s => (s.rowObfuscated ? 'NA' : s['4'])),
+    getSortableColumn('5', '5', s => (s.rowObfuscated ? 'NA' : s['5'])),
+    getSortableColumn('OTHER_PASSED', 'Other passed', s => (s.rowObfuscated ? 'NA' : s['Hyv.']))
   ]
   if (addHTAndTT)
-    columns.splice(6, 0, getSortableColumn('HT', 'HT', s => s.rowObfuscated ? 'NA' : s.HT), getSortableColumn('TT', 'TT', s => s.rowObfuscated ? 'NA' : s.TT))
+    columns.splice(
+      6,
+      0,
+      getSortableColumn('HT', 'HT', s => (s.rowObfuscated ? 'NA' : s.HT)),
+      getSortableColumn('TT', 'TT', s => (s.rowObfuscated ? 'NA' : s.TT))
+    )
   return columns
 }
 
@@ -82,28 +83,28 @@ const GradesTable = ({ stats, name, alternatives, separate, isRelative, populati
     return `/coursepopulation?${searchString}`
   }
 
-  const timeColumn = { ...getSortableColumn(
-    'TIME',
-    'Time',
-    s => s.code,
-    s => (
-      <div>
-        {s.name}
-        {(s.name !== 'Total' && populationsShouldBeVisible) ? (
-          <Item as={Link} to={showPopulation(s.code, s.name, s)}>
-            <Icon name="level up alternate" />
-          </Item>
-        ) : null}
-      </div>
+  const timeColumn = {
+    ...getSortableColumn(
+      'TIME',
+      'Time',
+      s => s.code,
+      s => (
+        <div>
+          {s.name}
+          {s.name !== 'Total' && populationsShouldBeVisible ? (
+            <Item as={Link} to={showPopulation(s.code, s.name, s)}>
+              <Icon name="level up alternate" />
+            </Item>
+          ) : null}
+        </div>
+      )
     ),
-  ),
-  cellProps: { width: 3 }
-}
-
+    cellProps: { width: 3 }
+  }
 
   const columns = [
     timeColumn,
-    getSortableColumn('ATTEMPTS', 'Attempts', s => s.rowObfuscated ? '5 or less students' : s.attempts),
+    getSortableColumn('ATTEMPTS', 'Attempts', s => (s.rowObfuscated ? '5 or less students' : s.attempts)),
     ...getGradeColumns(notThesisGrades, includesHTOrTT(stats))
   ]
 
@@ -131,7 +132,7 @@ GradesTable.propTypes = {
   alternatives: arrayOf(string).isRequired,
   separate: bool,
   isRelative: bool.isRequired,
-  populationsShouldBeVisible: bool,
+  populationsShouldBeVisible: bool.isRequired
 }
 
 GradesTable.defaultProps = {

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
@@ -10,7 +10,7 @@ import { defineCellColor } from '../util'
 
 const formatPercentage = p => `${(p * 100).toFixed(2)} %`
 
-const StudentTable = ({ stats, name, alternatives, separate }) => {
+const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBeVisible }) => {
   const showPopulation = (yearcode, years) => {
     const queryObject = {
       from: yearcode,
@@ -40,7 +40,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
             getRowContent: s => (
               <div>
                 {s.name}
-                {s.name !== 'Total' ? (
+                {(s.name !== 'Total' && populationsShouldBeVisible) ? (
                   <Item as={Link} to={showPopulation(s.code, s.name, s)}>
                     <Icon name="level up alternate" />
                   </Item>
@@ -53,7 +53,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'TOTAL',
             title: 'Students',
-            getRowVal: s => s.obfuscated ? '5 or less students' : s.students.total,
+            getRowVal: s => s.rowObfuscated ? '5 or less students' : s.students.total,
             getCellProps: s => defineCellColor(s),
             headerProps: { rowSpan: 2, width: 3 }
           },
@@ -66,7 +66,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'PASS_FIRST',
             title: 'first try',
-            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.passedFirst || 0,
+            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.passedFirst || 0,
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -74,7 +74,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'PASS_RETRY',
             title: 'after retry',
-            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.passedRetry || 0,
+            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.passedRetry || 0,
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -82,8 +82,8 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'PASS_RATE',
             title: 'percentage',
-            getRowVal: s => s.obfuscated ? 'NA' : s.students.passRate,
-            getRowContent: s => s.obfuscated ? 'NA' : formatPercentage(s.students.passRate),
+            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.passRate,
+            getRowContent: s => s.rowObfuscated ? 'NA' : formatPercentage(s.students.passRate),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 1 },
             child: true
@@ -97,7 +97,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'FAIL_FIRST',
             title: 'first try',
-            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.failedFirst || 0,
+            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.failedFirst || 0,
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -105,7 +105,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'FAIL_RETRY',
             title: 'after retry',
-            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.failedRetry || 0,
+            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.failedRetry || 0,
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -113,8 +113,8 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'FAIL_RATE',
             title: 'percentage',
-            getRowVal: s => s.obfuscated ? 'NA': s.students.failRate,
-            getRowContent: s => s.obfuscated ? 'NA' : formatPercentage(s.students.failRate),
+            getRowVal: s => s.rowObfuscated ? 'NA': s.students.failRate,
+            getRowContent: s => s.rowObfuscated ? 'NA' : formatPercentage(s.students.failRate),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 1 },
             child: true
@@ -130,7 +130,8 @@ StudentTable.propTypes = {
   stats: arrayOf(shape({})).isRequired,
   name: oneOfType([number, string]).isRequired,
   alternatives: arrayOf(string).isRequired,
-  separate: bool
+  separate: bool,
+  populationsShouldBeVisible: bool,
 }
 
 StudentTable.defaultProps = {

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
@@ -22,23 +22,6 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
     return `/coursepopulation?${searchString}`
   }
 
-  const formatted = stats.map(statistic => {
-    const { name: n, code, students, coursecode } = statistic
-    const { passedFirst = 0, passedRetry = 0, failedFirst = 0, failedRetry = 0 } = students.categories
-    const total = passedFirst + passedRetry + failedFirst + failedRetry
-    return {
-      name: n,
-      code,
-      coursecode,
-      students: total,
-      passedFirst,
-      passedRetry,
-      passRate: (passedFirst + passedRetry) / total,
-      failedFirst,
-      failedRetry,
-      failRate: (failedFirst + failedRetry) / total
-    }
-  })
   return (
     <div>
       <Header as="h3" textAlign="center">
@@ -63,12 +46,14 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
                 ) : null}
               </div>
             ),
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             headerProps: { rowSpan: 2, width: 3 }
           },
           {
             key: 'TOTAL',
             title: 'Students',
-            getRowVal: s => s.students,
+            getRowVal: s => s.obfuscated ? '5 or less students' : s.students.total,
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             headerProps: { rowSpan: 2, width: 3 }
           },
           {
@@ -80,22 +65,25 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'PASS_FIRST',
             title: 'first try',
-            getRowVal: s => s.passedFirst,
+            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.passedFirst || 0,
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 2 },
             child: true
           },
           {
             key: 'PASS_RETRY',
             title: 'after retry',
-            getRowVal: s => s.passedRetry,
+            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.passedRetry || 0,
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 2 },
             child: true
           },
           {
             key: 'PASS_RATE',
             title: 'percentage',
-            getRowVal: s => s.passRate,
-            getRowContent: s => formatPercentage(s.passRate),
+            getRowVal: s => s.obfuscated ? 'NA' : s.students.passRate,
+            getRowContent: s => s.obfuscated ? 'NA' : formatPercentage(s.students.passRate),
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 1 },
             child: true
           },
@@ -108,27 +96,30 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
           {
             key: 'FAIL_FIRST',
             title: 'first try',
-            getRowVal: s => s.failedFirst,
+            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.failedFirst || 0,
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 2 },
             child: true
           },
           {
             key: 'FAIL_RETRY',
             title: 'after retry',
-            getRowVal: s => s.failedRetry,
+            getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.failedRetry || 0,
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 2 },
             child: true
           },
           {
             key: 'FAIL_RATE',
             title: 'percentage',
-            getRowVal: s => s.failRate,
-            getRowContent: s => formatPercentage(s.failRate),
+            getRowVal: s => s.obfuscated ? 'NA': s.students.failRate,
+            getRowContent: s => s.obfuscated ? 'NA' : formatPercentage(s.students.failRate),
+            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
             cellProps: { width: 1 },
             child: true
           }
         ]}
-        data={formatted}
+        data={stats}
       />
     </div>
   )

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import { uniq } from 'lodash'
 import { shape, string, number, oneOfType, arrayOf, bool } from 'prop-types'
 import SortableTable from '../../../../SortableTable'
+import { defineCellColor } from '../util'
 
 const formatPercentage = p => `${(p * 100).toFixed(2)} %`
 
@@ -46,14 +47,14 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
                 ) : null}
               </div>
             ),
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             headerProps: { rowSpan: 2, width: 3 }
           },
           {
             key: 'TOTAL',
             title: 'Students',
             getRowVal: s => s.obfuscated ? '5 or less students' : s.students.total,
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             headerProps: { rowSpan: 2, width: 3 }
           },
           {
@@ -66,7 +67,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
             key: 'PASS_FIRST',
             title: 'first try',
             getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.passedFirst || 0,
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
           },
@@ -74,7 +75,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
             key: 'PASS_RETRY',
             title: 'after retry',
             getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.passedRetry || 0,
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
           },
@@ -83,7 +84,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
             title: 'percentage',
             getRowVal: s => s.obfuscated ? 'NA' : s.students.passRate,
             getRowContent: s => s.obfuscated ? 'NA' : formatPercentage(s.students.passRate),
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 1 },
             child: true
           },
@@ -97,7 +98,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
             key: 'FAIL_FIRST',
             title: 'first try',
             getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.failedFirst || 0,
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
           },
@@ -105,7 +106,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
             key: 'FAIL_RETRY',
             title: 'after retry',
             getRowVal: s => s.obfuscated ? 'NA' : s.students.categories.failedRetry || 0,
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
           },
@@ -114,7 +115,7 @@ const StudentTable = ({ stats, name, alternatives, separate }) => {
             title: 'percentage',
             getRowVal: s => s.obfuscated ? 'NA': s.students.failRate,
             getRowContent: s => s.obfuscated ? 'NA' : formatPercentage(s.students.failRate),
-            getCellProps: s => s.obfuscated && { style: { color: 'gray' } },
+            getCellProps: s => defineCellColor(s),
             cellProps: { width: 1 },
             child: true
           }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/Tables/student.jsx
@@ -40,7 +40,7 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
             getRowContent: s => (
               <div>
                 {s.name}
-                {(s.name !== 'Total' && populationsShouldBeVisible) ? (
+                {s.name !== 'Total' && populationsShouldBeVisible ? (
                   <Item as={Link} to={showPopulation(s.code, s.name, s)}>
                     <Icon name="level up alternate" />
                   </Item>
@@ -53,7 +53,7 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
           {
             key: 'TOTAL',
             title: 'Students',
-            getRowVal: s => s.rowObfuscated ? '5 or less students' : s.students.total,
+            getRowVal: s => (s.rowObfuscated ? '5 or less students' : s.students.total),
             getCellProps: s => defineCellColor(s),
             headerProps: { rowSpan: 2, width: 3 }
           },
@@ -66,7 +66,7 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
           {
             key: 'PASS_FIRST',
             title: 'first try',
-            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.passedFirst || 0,
+            getRowVal: s => (s.rowObfuscated ? 'NA' : s.students.categories.passedFirst || 0),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -74,7 +74,7 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
           {
             key: 'PASS_RETRY',
             title: 'after retry',
-            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.passedRetry || 0,
+            getRowVal: s => (s.rowObfuscated ? 'NA' : s.students.categories.passedRetry || 0),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -82,8 +82,8 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
           {
             key: 'PASS_RATE',
             title: 'percentage',
-            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.passRate,
-            getRowContent: s => s.rowObfuscated ? 'NA' : formatPercentage(s.students.passRate),
+            getRowVal: s => (s.rowObfuscated ? 'NA' : s.students.passRate),
+            getRowContent: s => (s.rowObfuscated ? 'NA' : formatPercentage(s.students.passRate)),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 1 },
             child: true
@@ -97,7 +97,7 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
           {
             key: 'FAIL_FIRST',
             title: 'first try',
-            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.failedFirst || 0,
+            getRowVal: s => (s.rowObfuscated ? 'NA' : s.students.categories.failedFirst || 0),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -105,7 +105,7 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
           {
             key: 'FAIL_RETRY',
             title: 'after retry',
-            getRowVal: s => s.rowObfuscated ? 'NA' : s.students.categories.failedRetry || 0,
+            getRowVal: s => (s.rowObfuscated ? 'NA' : s.students.categories.failedRetry || 0),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 2 },
             child: true
@@ -113,8 +113,8 @@ const StudentTable = ({ stats, name, alternatives, separate, populationsShouldBe
           {
             key: 'FAIL_RATE',
             title: 'percentage',
-            getRowVal: s => s.rowObfuscated ? 'NA': s.students.failRate,
-            getRowContent: s => s.rowObfuscated ? 'NA' : formatPercentage(s.students.failRate),
+            getRowVal: s => (s.rowObfuscated ? 'NA' : s.students.failRate),
+            getRowContent: s => (s.rowObfuscated ? 'NA' : formatPercentage(s.students.failRate)),
             getCellProps: s => defineCellColor(s),
             cellProps: { width: 1 },
             child: true
@@ -131,7 +131,7 @@ StudentTable.propTypes = {
   name: oneOfType([number, string]).isRequired,
   alternatives: arrayOf(string).isRequired,
   separate: bool,
-  populationsShouldBeVisible: bool,
+  populationsShouldBeVisible: bool.isRequired
 }
 
 StudentTable.defaultProps = {

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
@@ -12,8 +12,6 @@ const Tables = ({ primary, comparison, viewMode, alternatives, separate, isRelat
     switch (viewMode) {
       case viewModeNames.CUMULATIVE:
         return <CumulativeTable separate={separate} name={name} stats={stats} alternatives={alternatives} />
-      case viewModeNames.STUDENT:
-        return <StudentTable separate={separate} name={name} stats={stats} alternatives={alternatives} />
       case viewModeNames.GRADES:
         return (
           <GradesTable
@@ -24,6 +22,8 @@ const Tables = ({ primary, comparison, viewMode, alternatives, separate, isRelat
             isRelative={isRelative}
           />
         )
+      case viewModeNames.STUDENT:
+        return <StudentTable separate={separate} name={name} stats={stats} alternatives={alternatives} />
       default:
         return null
     }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
@@ -20,7 +20,7 @@ const Tables = ({ primary, comparison, viewMode, alternatives, separate, isRelat
             alternatives={alternatives}
             populationsShouldBeVisible={populationsShouldBeVisible}
           />
-        ) 
+        )
       case viewModeNames.GRADES:
         return (
           <GradesTable
@@ -30,7 +30,6 @@ const Tables = ({ primary, comparison, viewMode, alternatives, separate, isRelat
             alternatives={alternatives}
             isRelative={isRelative}
             populationsShouldBeVisible={populationsShouldBeVisible}
-
           />
         )
       case viewModeNames.STUDENT:

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
@@ -9,7 +9,7 @@ import GradesTable from './Tables/grades'
 
 const Tables = ({ primary, comparison, viewMode, alternatives, separate, isRelative }) => {
   const getViewMode = (name, stats) => {
-    const populationsShouldBeVisible = stats[0].userHasAccessToAllData
+    const populationsShouldBeVisible = stats[0].userHasAccessToAllStats
     switch (viewMode) {
       case viewModeNames.CUMULATIVE:
         return (

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/tables.jsx
@@ -9,9 +9,18 @@ import GradesTable from './Tables/grades'
 
 const Tables = ({ primary, comparison, viewMode, alternatives, separate, isRelative }) => {
   const getViewMode = (name, stats) => {
+    const populationsShouldBeVisible = stats[0].userHasAccessToAllData
     switch (viewMode) {
       case viewModeNames.CUMULATIVE:
-        return <CumulativeTable separate={separate} name={name} stats={stats} alternatives={alternatives} />
+        return (
+          <CumulativeTable
+            separate={separate}
+            name={name}
+            stats={stats}
+            alternatives={alternatives}
+            populationsShouldBeVisible={populationsShouldBeVisible}
+          />
+        ) 
       case viewModeNames.GRADES:
         return (
           <GradesTable
@@ -20,10 +29,20 @@ const Tables = ({ primary, comparison, viewMode, alternatives, separate, isRelat
             stats={stats}
             alternatives={alternatives}
             isRelative={isRelative}
+            populationsShouldBeVisible={populationsShouldBeVisible}
+
           />
         )
       case viewModeNames.STUDENT:
-        return <StudentTable separate={separate} name={name} stats={stats} alternatives={alternatives} />
+        return (
+          <StudentTable
+            separate={separate}
+            name={name}
+            stats={stats}
+            alternatives={alternatives}
+            populationsShouldBeVisible={populationsShouldBeVisible}
+          />
+        )
       default:
         return null
     }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
@@ -2,8 +2,8 @@ import { arrayOf, number, oneOfType, shape, string, oneOf } from 'prop-types'
 
 export const viewModeNames = {
   CUMULATIVE: 'Cumulative',
-  STUDENT: 'Student',
-  GRADES: 'Grades'
+  GRADES: 'Grades',
+  STUDENT: 'Student'
 }
 
 export const getDataObject = (name, data, stack) => ({ name, data, stack })

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
@@ -121,6 +121,6 @@ export const getGradeSpread = (series, isRelative) => {
   return isRelative ? relative : newSeries
 }
 
-export const defineCellColor = (s) => {
+export const defineCellColor = s => {
   return s.rowObfuscated && { style: { color: 'gray' } }
 }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
@@ -122,5 +122,5 @@ export const getGradeSpread = (series, isRelative) => {
 }
 
 export const defineCellColor = (s) => {
-  return s.obfuscated && { style: { color: 'gray' } }
+  return s.rowObfuscated && { style: { color: 'gray' } }
 }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/Panes/util.js
@@ -120,3 +120,7 @@ export const getGradeSpread = (series, isRelative) => {
 
   return isRelative ? relative : newSeries
 }
+
+export const defineCellColor = (s) => {
+  return s.obfuscated && { style: { color: 'gray' } }
+}

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/index.jsx
@@ -39,21 +39,25 @@ const ResultTabs = props => {
     setViewMode(newViewMode)
   }
 
+  const getRelativeButton = () => (
+    <div className="toggleContainer">
+      <label className="toggleLabel">Absolute</label>
+        <Radio toggle checked={isRelative} onChange={() => setIsRelative(!isRelative)} />
+      <label className="toggleLabel">Relative</label>
+    </div>
+  )
+
   const renderViewModeSelector = () => {
     const isTogglePane = tab !== 0
     const getButtonMenu = () => (
-      <Menu secondary>
-        {Object.values(viewModeNames).map(name => (
-          <Menu.Item key={name} name={name} active={viewMode === name} onClick={() => handleModeChange(name)} />
-        ))}
-        {viewMode === 'Grades' && (
-          <Menu.Item
-            name={isRelative ? 'Set absolute' : 'Set relative'}
-            active={isRelative}
-            onClick={() => setIsRelative(!isRelative)}
-          />
-        )}
-      </Menu>
+      <>
+        <Menu secondary>
+          {Object.values(viewModeNames).map(name => (
+            <Menu.Item key={name} name={name} active={viewMode === name} onClick={() => handleModeChange(name)} />
+          ))}
+        </Menu>
+        {viewMode === 'Grades' && getRelativeButton()}
+      </>
     )
 
     const getToggle = () => {
@@ -71,13 +75,7 @@ const ResultTabs = props => {
               {viewModeNames.STUDENT}
             </label>
           </div>
-          {(tab === 2 || props.comparison) && (
-            <div className="toggleContainer">
-              <label className="toggleLabel">Absolute</label>
-              <Radio toggle checked={isRelative} onChange={() => setIsRelative(!isRelative)} />
-              <label className="toggleLabel">Relative</label>
-            </div>
-          )}
+          {(tab === 2 || props.comparison) && getRelativeButton()}
         </div>
       )
     }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/ResultTabs/index.jsx
@@ -42,7 +42,7 @@ const ResultTabs = props => {
   const getRelativeButton = () => (
     <div className="toggleContainer">
       <label className="toggleLabel">Absolute</label>
-        <Radio toggle checked={isRelative} onChange={() => setIsRelative(!isRelative)} />
+      <Radio toggle checked={isRelative} onChange={() => setIsRelative(!isRelative)} />
       <label className="toggleLabel">Relative</label>
     </div>
   )

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
@@ -154,7 +154,7 @@ const SingleCourseStats = ({
     const progStats = statistics
       .filter(isStatInYearRange)
       .map(({ code, name, students: allstudents, attempts, coursecode, obfuscated }) => {
-        const cumulative = {
+        let cumulative = {
           grades: countFilteredStudents(attempts.grades, filter),
           categories: countFilteredStudents(attempts.classes, filter)
         }
@@ -162,12 +162,14 @@ const SingleCourseStats = ({
           grades: countFilteredStudents(allstudents.grades, filter),
           categories: countFilteredStudents(allstudents.classes, filter)
         }
+        const { failed, passed } = cumulative.categories
+        cumulative.categories.passRate = (100 * passed) / (passed + failed)
 
         const parsedName = separate ? getTextIn(name, language) : name
         return { code, name: parsedName, cumulative, students, coursecode, obfuscated }
       })
 
-    const totals = progStats.reduce(
+    let totals = progStats.reduce(
       (acc, curr) => {
         const passed = acc.cumulative.categories.passed + curr.cumulative.categories.passed
         const failed = acc.cumulative.categories.failed + curr.cumulative.categories.failed
@@ -207,7 +209,8 @@ const SingleCourseStats = ({
         cumulative: {
           categories: {
             passed: 0,
-            failed: 0
+            failed: 0,
+            passrate: 0,
           },
           grades: {}
         },
@@ -220,6 +223,10 @@ const SingleCourseStats = ({
         }
       }
     )
+
+    const { failed, passed } = totals.cumulative.categories
+    totals.cumulative.categories.passRate = (100 * passed) / (passed + failed)
+
     return {
       codes: progCodes.concat,
       name,

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
@@ -22,7 +22,7 @@ import useLanguage from '../../LanguagePicker/useLanguage'
 const ANALYTICS_CATEGORY = 'Course Statistics'
 const sendAnalytics = (action, name, value) => TSA.Matomo.sendEvent(ANALYTICS_CATEGORY, action, name, value)
 
-const countFilteredStudents = (stat, filter) => (
+const countFilteredStudents = (stat, filter) =>
   Object.entries(stat).reduce((acc, entry) => {
     const [category, students] = entry
     return {
@@ -30,7 +30,6 @@ const countFilteredStudents = (stat, filter) => (
       [category]: students.filter(filter).length
     }
   }, {})
-)
 
 const SingleCourseStats = ({
   stats,
@@ -168,7 +167,7 @@ const SingleCourseStats = ({
   const countStudentStats = (allstudents, filter) => {
     const grades = countFilteredStudents(allstudents.grades, filter)
     const categories = countFilteredStudents(allstudents.classes, filter)
-  
+
     const { passedFirst = 0, passedRetry = 0, failedFirst = 0, failedRetry = 0 } = categories
     const total = passedFirst + passedRetry + failedFirst + failedRetry
     const passRate = (passedFirst + passedRetry) / total
@@ -181,7 +180,7 @@ const SingleCourseStats = ({
       failRate,
       total
     }
-  } 
+  }
 
   const statsForProgrammes = (progCodes, name) => {
     const { statistics } = stats
@@ -189,7 +188,6 @@ const SingleCourseStats = ({
     const progStats = statistics
       .filter(isStatInYearRange)
       .map(({ code, name, students: allstudents, attempts, coursecode, obfuscated }) => {
-
         const cumulative = countCumulativeStats(attempts, filter)
         const students = countStudentStats(allstudents, filter)
 
@@ -205,11 +203,11 @@ const SingleCourseStats = ({
         }
       })
 
-    let totals = progStats.reduce(
+    const totals = progStats.reduce(
       (acc, curr) => {
         if (curr.rowObfuscated) {
           return acc
-        } 
+        }
         const passed = acc.cumulative.categories.passed + curr.cumulative.categories.passed
         const failed = acc.cumulative.categories.failed + curr.cumulative.categories.failed
         const cgrades = acc.cumulative.grades
@@ -248,10 +246,10 @@ const SingleCourseStats = ({
         cumulative: {
           categories: {
             passed: 0,
-            failed: 0,
+            failed: 0
           },
           passRate: 0,
-          grades: {},
+          grades: {}
         },
         students: {
           categories: {
@@ -414,7 +412,7 @@ const SingleCourseStats = ({
           )}
         </Form>
       </Segment>
-      {userHasAccessToAllStats &&
+      {userHasAccessToAllStats && (
         <Segment>
           <Form>
             <Header as="h4">Filter statistics by study programmes</Header>
@@ -453,7 +451,7 @@ const SingleCourseStats = ({
             </Grid>
           </Form>
         </Segment>
-      }
+      )}
       <ResultTabs separate={separate} primary={statistics.primary} comparison={statistics.comparison} />
     </div>
   )
@@ -495,7 +493,7 @@ SingleCourseStats.propTypes = {
   }).isRequired,
   getMaxYearsToCreatePopulationFrom: func.isRequired,
   maxYearsToCreatePopulationFrom: number.isRequired,
-  userHasAccessToAllStats: bool,
+  userHasAccessToAllStats: bool.isRequired
 }
 
 const mapStateToProps = state => {

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
@@ -243,6 +243,7 @@ const SingleCourseStats = ({
         code: 9999,
         name: 'Total',
         coursecode: '000',
+        userHasAccessToAllStats,
         cumulative: {
           categories: {
             passed: 0,

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
@@ -153,7 +153,7 @@ const SingleCourseStats = ({
     const filter = belongsToAtLeastOneProgramme(progCodes)
     const progStats = statistics
       .filter(isStatInYearRange)
-      .map(({ code, name, students: allstudents, attempts, coursecode }) => {
+      .map(({ code, name, students: allstudents, attempts, coursecode, obfuscated }) => {
         const cumulative = {
           grades: countFilteredStudents(attempts.grades, filter),
           categories: countFilteredStudents(attempts.classes, filter)
@@ -162,8 +162,9 @@ const SingleCourseStats = ({
           grades: countFilteredStudents(allstudents.grades, filter),
           categories: countFilteredStudents(allstudents.classes, filter)
         }
+
         const parsedName = separate ? getTextIn(name, language) : name
-        return { code, name: parsedName, cumulative, students, coursecode }
+        return { code, name: parsedName, cumulative, students, coursecode, obfuscated }
       })
 
     const totals = progStats.reduce(

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseStats/index.jsx
@@ -43,7 +43,8 @@ const SingleCourseStats = ({
   semesters,
   programmes,
   maxYearsToCreatePopulationFrom,
-  getMaxYearsToCreatePopulationFrom
+  getMaxYearsToCreatePopulationFrom,
+  userHasAccessToAllStats
 }) => {
   const { language } = useLanguage()
   const [primary, setPrimary] = useState([ALL.value])
@@ -355,44 +356,46 @@ const SingleCourseStats = ({
           )}
         </Form>
       </Segment>
-      <Segment>
-        <Form>
-          <Header as="h4">Filter statistics by study programmes</Header>
-          <Grid>
-            <Grid.Column width={8}>
-              <ProgrammeDropdown
-                name="primary"
-                options={options}
-                label="Primary group"
-                placeholder="Select study programmes"
-                value={primary}
-                onChange={handleSelect}
-              />
-            </Grid.Column>
-            <Grid.Column width={8}>
-              <ProgrammeDropdown
-                name="comparison"
-                options={comparisonProgrammes(options)}
-                label="Comparison group"
-                placeholder="Optional"
-                value={comparison}
-                onChange={handleSelect}
-              />
-            </Grid.Column>
-            <Grid.Column width={8} />
-            <Grid.Column width={8}>
-              <Form.Group>
-                <Form.Button
-                  content="Select excluded study programmes"
-                  onClick={setExcludedToComparison}
-                  disabled={primary.length === 1 && primary[0] === ALL.value}
+      {userHasAccessToAllStats &&
+        <Segment>
+          <Form>
+            <Header as="h4">Filter statistics by study programmes</Header>
+            <Grid>
+              <Grid.Column width={8}>
+                <ProgrammeDropdown
+                  name="primary"
+                  options={options}
+                  label="Primary group"
+                  placeholder="Select study programmes"
+                  value={primary}
+                  onChange={handleSelect}
                 />
-                <Form.Button content="Clear" onClick={clearComparison} />
-              </Form.Group>
-            </Grid.Column>
-          </Grid>
-        </Form>
-      </Segment>
+              </Grid.Column>
+              <Grid.Column width={8}>
+                <ProgrammeDropdown
+                  name="comparison"
+                  options={comparisonProgrammes(options)}
+                  label="Comparison group"
+                  placeholder="Optional"
+                  value={comparison}
+                  onChange={handleSelect}
+                />
+              </Grid.Column>
+              <Grid.Column width={8} />
+              <Grid.Column width={8}>
+                <Form.Group>
+                  <Form.Button
+                    content="Select excluded study programmes"
+                    onClick={setExcludedToComparison}
+                    disabled={primary.length === 1 && primary[0] === ALL.value}
+                  />
+                  <Form.Button content="Clear" onClick={clearComparison} />
+                </Form.Group>
+              </Grid.Column>
+            </Grid>
+          </Form>
+        </Segment>
+      }
       <ResultTabs separate={separate} primary={statistics.primary} comparison={statistics.comparison} />
     </div>
   )

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseTab/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseTab/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { connect } from 'react-redux'
 import { Segment, Label, Header, Divider, Form } from 'semantic-ui-react'
-import { shape, arrayOf, oneOfType, number, string } from 'prop-types'
+import { shape, arrayOf, oneOfType, number, string, bool } from 'prop-types'
 import SingleCourseStats from '../SingleCourseStats'
 import useLanguage from '../../LanguagePicker/useLanguage'
 import selectors from '../../../selectors/courseStats'
@@ -44,7 +44,7 @@ const SingleCourseTab = ({ selected, stats, courses, userHasAccessToAllStats }) 
           </Label.Group>
         </Form>
       </Segment>
-      {selection && <SingleCourseStats stats={stats[selection]} userHasAccessToAllStats={userHasAccessToAllStats}/>}
+      {selection && <SingleCourseStats stats={stats[selection]} userHasAccessToAllStats={userHasAccessToAllStats} />}
     </div>
   )
 }
@@ -52,7 +52,8 @@ const SingleCourseTab = ({ selected, stats, courses, userHasAccessToAllStats }) 
 SingleCourseTab.propTypes = {
   stats: shape({}).isRequired,
   courses: arrayOf(shape({})).isRequired,
-  selected: oneOfType([number, string]).isRequired
+  selected: oneOfType([number, string]).isRequired,
+  userHasAccessToAllStats: bool.isRequired
 }
 
 const mapStateToProps = state => ({

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseTab/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SingleCourseTab/index.jsx
@@ -7,7 +7,7 @@ import useLanguage from '../../LanguagePicker/useLanguage'
 import selectors from '../../../selectors/courseStats'
 import { getTextIn } from '../../../common'
 
-const SingleCourseTab = ({ selected, stats, courses }) => {
+const SingleCourseTab = ({ selected, stats, courses, userHasAccessToAllStats }) => {
   const [selection, setSelection] = useState(selected)
   const { language } = useLanguage()
 
@@ -44,7 +44,7 @@ const SingleCourseTab = ({ selected, stats, courses }) => {
           </Label.Group>
         </Form>
       </Segment>
-      {selection && <SingleCourseStats stats={stats[selection]} />}
+      {selection && <SingleCourseStats stats={stats[selection]} userHasAccessToAllStats={userHasAccessToAllStats}/>}
     </div>
   )
 }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SummaryTab/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SummaryTab/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Form, Label, Segment, Header } from 'semantic-ui-react'
 import { connect } from 'react-redux'
-import { shape, arrayOf, func, oneOfType, number, string } from 'prop-types'
+import { shape, arrayOf, func, oneOfType, number, string, bool } from 'prop-types'
 import { flatten } from 'lodash'
 import selectors, { ALL } from '../../../selectors/courseStats'
 import { fields, setValue } from '../../../redux/coursesSummaryForm'
@@ -62,7 +62,7 @@ const SummaryTab = ({ form, setValue, statistics, programmes, queryInfo, onClick
     <div>
       <Segment>
         <Form>
-          {userHasAccessToAllStats &&
+          {userHasAccessToAllStats && (
             <>
               <Header as="h4">Filter statistics by study programmes</Header>
               <ProgrammeDropdown
@@ -73,7 +73,7 @@ const SummaryTab = ({ form, setValue, statistics, programmes, queryInfo, onClick
                 value={form[fields.programmes]}
               />
             </>
-          }
+          )}
           <Form.Field>
             <label>Timeframe:</label>
             <Label.Group>
@@ -114,12 +114,13 @@ SummaryTab.propTypes = {
     courses: arrayOf(shape({})),
     timeframe: arrayOf(shape({}))
   }).isRequired,
-  onClickCourse: func.isRequired
+  onClickCourse: func.isRequired,
+  userHasAccessToAllStats: bool.isRequired
 }
 
 const mapStateToProps = state => {
-  const roles = state.auth.token.roles
-  const rights = state.auth.token.rights
+  const { roles } = state.auth.token
+  const { rights } = state.auth.token
   const userHasAccessToAllStats = userHasAccessToAllCourseStats(roles, rights)
   const programmes = selectors.getAllStudyProgrammes(state)
   const programmeCodes = state.courseSummaryForm[fields.programmes]

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SummaryTab/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SummaryTab/index.jsx
@@ -9,6 +9,7 @@ import CumulativeTable from '../CumulativeTable'
 import ProgrammeDropdown from '../ProgrammeDropdown'
 import useLanguage from '../../LanguagePicker/useLanguage'
 import { getTextIn } from '../../../common'
+import { userHasAccessToAllCourseStats } from '../courseStatisticsUtils'
 
 // Certified JavaScript moment but basically this was crashing
 // since sometimes object like {en: ..., fi: ...., sv: ....}
@@ -113,11 +114,14 @@ SummaryTab.propTypes = {
 }
 
 const mapStateToProps = state => {
+  const roles = state.auth.token.roles
+  const rights = state.auth.token.rights
+  const userHasAccessToAllStats = userHasAccessToAllCourseStats(roles, rights)
   const programmes = selectors.getAllStudyProgrammes(state)
   const programmeCodes = state.courseSummaryForm[fields.programmes]
   return {
     form: state.courseSummaryForm,
-    statistics: selectors.summaryStatistics(state, { programmes, programmeCodes }),
+    statistics: selectors.summaryStatistics(state, { programmes, programmeCodes }, userHasAccessToAllStats),
     queryInfo: selectors.getQueryInfo(state),
     programmes
   }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/SummaryTab/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/SummaryTab/index.jsx
@@ -27,7 +27,7 @@ const unObjectifyProperty = ({ obj, property }) => {
   return { ...obj, [property]: suspectField }
 }
 
-const SummaryTab = ({ form, setValue, statistics, programmes, queryInfo, onClickCourse }) => {
+const SummaryTab = ({ form, setValue, statistics, programmes, queryInfo, onClickCourse, userHasAccessToAllStats }) => {
   const { language } = useLanguage()
   const handleChange = (e, { name, value }) => {
     let selected = [...value].filter(v => v !== ALL.value)
@@ -62,14 +62,18 @@ const SummaryTab = ({ form, setValue, statistics, programmes, queryInfo, onClick
     <div>
       <Segment>
         <Form>
-          <Header as="h4">Filter statistics by study programmes</Header>
-          <ProgrammeDropdown
-            options={options}
-            label="Study programmes:"
-            name={fields.programmes}
-            onChange={handleChange}
-            value={form[fields.programmes]}
-          />
+          {userHasAccessToAllStats &&
+            <>
+              <Header as="h4">Filter statistics by study programmes</Header>
+              <ProgrammeDropdown
+                options={options}
+                label="Study programmes:"
+                name={fields.programmes}
+                onChange={handleChange}
+                value={form[fields.programmes]}
+              />
+            </>
+          }
           <Form.Field>
             <label>Timeframe:</label>
             <Label.Group>

--- a/services/oodikone2-frontend/src/components/CourseStatistics/courseStatisticsUtils.js
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/courseStatisticsUtils.js
@@ -32,4 +32,8 @@ const getActiveYears = course => {
   return `${startYearText} — ${endYearText}`
 }
 
-export { getActiveYears, getYearText }
+const userHasAccessToAllCourseStats = (roles, rights) => {
+  return (roles && ['admin'].find(role => roles.includes(role))) || rights.length > 0
+}
+
+export { getActiveYears, getYearText, userHasAccessToAllCourseStats }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/courseStatisticsUtils.js
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/courseStatisticsUtils.js
@@ -33,7 +33,7 @@ const getActiveYears = course => {
 }
 
 const userHasAccessToAllCourseStats = (roles, rights) => {
-  return (roles && ['admin'].find(role => roles.includes(role))) || rights.length > 0
+  return (roles && ['admin'].some(role => roles.includes(role))) || rights.length > 0
 }
 
 export { getActiveYears, getYearText, userHasAccessToAllCourseStats }

--- a/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
@@ -67,7 +67,7 @@ const CourseStatistics = props => {
     let panes = [
       {
         menuItem: MENU.SUM,
-        render: () => <SummaryTab onClickCourse={switchToCourse} />
+        render: () => <SummaryTab onClickCourse={switchToCourse} userHasAccessToAllStats={userHasAccessToAllStats} />
       },
       {
         menuItem: MENU.COURSE,

--- a/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
@@ -71,12 +71,15 @@ const CourseStatistics = props => {
       },
       {
         menuItem: MENU.COURSE,
-        render: () => <SingleCourseTab selected={selected || initCourseCode} userHasAccessToAllStats={userHasAccessToAllStats} />
-      },
+        render: () => (
+          <SingleCourseTab selected={selected || initCourseCode} userHasAccessToAllStats={userHasAccessToAllStats} />
+        )
+      }
     ]
 
     if (userHasAccessToAllStats) {
-      panes = [...panes,
+      panes = [
+        ...panes,
         {
           menuItem: MENU.FACULTY,
           render: () => <FacultyLevelStatistics />
@@ -84,7 +87,8 @@ const CourseStatistics = props => {
       ]
     }
 
-    panes = [...panes,
+    panes = [
+      ...panes,
       {
         menuItem: {
           key: 'query',
@@ -124,13 +128,7 @@ const CourseStatistics = props => {
 
   const getContent = () => {
     if ((statsIsEmpty && diffIsEmpty) || history.location.search === '') {
-      return (
-        <SearchForm
-          onProgress={onProgress}
-          showDiff={showDiff}
-          setShowDiff={setShowDiff}
-        />
-      )
+      return <SearchForm onProgress={onProgress} showDiff={showDiff} setShowDiff={setShowDiff} />
     }
     if (showDiff) {
       return <CourseDiff />

--- a/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
@@ -13,6 +13,7 @@ import ProgressBar from '../ProgressBar'
 import { useProgress, useTitle } from '../../common/hooks'
 import { clearCourseStats } from '../../redux/coursestats'
 import { getUserRoles, checkUserAccess } from '../../common'
+import { userHasAccessToAllCourseStats } from './courseStatisticsUtils'
 import TSA from '../../common/tsa'
 
 const ANALYTICS_CATEGORY = 'Course Statistics'
@@ -61,7 +62,7 @@ const CourseStatistics = props => {
   }
 
   const getPanes = () => {
-    const panes = [
+    let panes = [
       {
         menuItem: MENU.SUM,
         render: () => <SummaryTab onClickCourse={switchToCourse} />
@@ -70,10 +71,18 @@ const CourseStatistics = props => {
         menuItem: MENU.COURSE,
         render: () => <SingleCourseTab selected={selected || initCourseCode} />
       },
-      {
-        menuItem: MENU.FACULTY,
-        render: () => <FacultyLevelStatistics />
-      },
+    ]
+
+    if (userHasAccessToAllCourseStats(userRoles, rights)) {
+      panes = [...panes,
+        {
+          menuItem: MENU.FACULTY,
+          render: () => <FacultyLevelStatistics />
+        }
+      ]
+    }
+
+    panes = [...panes,
       {
         menuItem: {
           key: 'query',
@@ -89,6 +98,7 @@ const CourseStatistics = props => {
         render: () => null
       }
     ]
+
     return !singleCourseStats ? panes : panes.filter(p => p.menuItem !== MENU.SUM)
   }
 

--- a/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
+++ b/services/oodikone2-frontend/src/components/CourseStatistics/index.jsx
@@ -61,6 +61,8 @@ const CourseStatistics = props => {
     setSelected(coursecode)
   }
 
+  const userHasAccessToAllStats = userHasAccessToAllCourseStats(userRoles, rights)
+
   const getPanes = () => {
     let panes = [
       {
@@ -69,11 +71,11 @@ const CourseStatistics = props => {
       },
       {
         menuItem: MENU.COURSE,
-        render: () => <SingleCourseTab selected={selected || initCourseCode} />
+        render: () => <SingleCourseTab selected={selected || initCourseCode} userHasAccessToAllStats={userHasAccessToAllStats} />
       },
     ]
 
-    if (userHasAccessToAllCourseStats(userRoles, rights)) {
+    if (userHasAccessToAllStats) {
       panes = [...panes,
         {
           menuItem: MENU.FACULTY,
@@ -122,7 +124,13 @@ const CourseStatistics = props => {
 
   const getContent = () => {
     if ((statsIsEmpty && diffIsEmpty) || history.location.search === '') {
-      return <SearchForm onProgress={onProgress} showDiff={showDiff} setShowDiff={setShowDiff} />
+      return (
+        <SearchForm
+          onProgress={onProgress}
+          showDiff={showDiff}
+          setShowDiff={setShowDiff}
+        />
+      )
     }
     if (showDiff) {
       return <CourseDiff />

--- a/services/oodikone2-frontend/src/selectors/courseStats.js
+++ b/services/oodikone2-frontend/src/selectors/courseStats.js
@@ -119,11 +119,12 @@ const calculatePassRate = (passed, failed) => {
   return passRate ? passRate.toFixed(2) : null
 }
 
-const getRealisationStats = (realisation, filterStudentFn) => {
+const getRealisationStats = (realisation, filterStudentFn, userHasAccessToAllStats) => {
   const { name, attempts } = realisation
   const { passed, failed } = attempts.classes
-  const passedAmount = passed.filter(filterStudentFn).length
-  const failedAmount = failed.filter(filterStudentFn).length
+  const passedAmount = userHasAccessToAllStats ? passed.filter(filterStudentFn).length : passed.length
+  const failedAmount = userHasAccessToAllStats ? failed.filter(filterStudentFn).length : failed.length
+
   return {
     passed: passedAmount,
     failed: failedAmount,
@@ -132,7 +133,7 @@ const getRealisationStats = (realisation, filterStudentFn) => {
   }
 }
 
-const getSummaryStats = (statistics, filterStudentFn) => {
+const getSummaryStats = (statistics, filterStudentFn, userHasAccessToAllStats) => {
   const summaryAcc = {
     passed: 0,
     failed: 0
@@ -140,8 +141,8 @@ const getSummaryStats = (statistics, filterStudentFn) => {
 
   const summary = statistics.reduce((acc, cur) => {
     const { passed, failed } = cur.attempts.classes
-    acc.passed += passed.filter(filterStudentFn).length
-    acc.failed += failed.filter(filterStudentFn).length
+    acc.passed += userHasAccessToAllStats ? passed.filter(filterStudentFn).length : passed.length
+    acc.failed += userHasAccessToAllStats ? failed.filter(filterStudentFn).length : failed.length
     return acc
   }, summaryAcc)
 
@@ -153,7 +154,7 @@ const getSummaryStats = (statistics, filterStudentFn) => {
 const summaryStatistics = createSelector(
   getCourseStats,
   getProgrammesFromProps,
-  (courseStats, { programmeCodes, programmes }) => {
+  (courseStats, { programmeCodes, programmes }, userHasAccessToAllStats) => {
     const filteredProgrammes = programmes.filter(p => programmeCodes.includes(p.key))
     const students = new Set(filteredProgrammes.reduce((acc, p) => [...acc, ...flatten(Object.values(p.students))], []))
 
@@ -162,8 +163,10 @@ const summaryStatistics = createSelector(
       const [coursecode, data] = entry
       const { statistics, name } = data
 
-      const realisations = statistics.map(realisation => getRealisationStats(realisation, filterStudentFn))
-      const summary = getSummaryStats(statistics, filterStudentFn)
+      // No filters based on programmes can be applied, if the programme and student number-data
+      // has been obfuscated 
+      const realisations = statistics.map(realisation => getRealisationStats(realisation, filterStudentFn, userHasAccessToAllStats))
+      const summary = getSummaryStats(statistics, filterStudentFn, userHasAccessToAllStats)
 
       return {
         coursecode,

--- a/services/oodikone2-frontend/src/selectors/courseStats.js
+++ b/services/oodikone2-frontend/src/selectors/courseStats.js
@@ -120,7 +120,7 @@ const calculatePassRate = (passed, failed) => {
 }
 
 const getRealisationStats = (realisation, filterStudentFn, userHasAccessToAllStats) => {
-  const { name, attempts } = realisation
+  const { name, attempts, obfuscated } = realisation
   const { passed, failed } = attempts.classes
   const passedAmount = userHasAccessToAllStats ? passed.filter(filterStudentFn).length : passed.length
   const failedAmount = userHasAccessToAllStats ? failed.filter(filterStudentFn).length : failed.length
@@ -129,7 +129,8 @@ const getRealisationStats = (realisation, filterStudentFn, userHasAccessToAllSta
     passed: passedAmount,
     failed: failedAmount,
     realisation: name,
-    passrate: calculatePassRate(passedAmount, failedAmount)
+    passrate: calculatePassRate(passedAmount, failedAmount),
+    obfuscated
   }
 }
 

--- a/services/oodikone2-frontend/src/selectors/courseStats.js
+++ b/services/oodikone2-frontend/src/selectors/courseStats.js
@@ -165,8 +165,10 @@ const summaryStatistics = createSelector(
       const { statistics, name } = data
 
       // No filters based on programmes can be applied, if the programme and student number-data
-      // has been obfuscated 
-      const realisations = statistics.map(realisation => getRealisationStats(realisation, filterStudentFn, userHasAccessToAllStats))
+      // has been obfuscated
+      const realisations = statistics.map(realisation =>
+        getRealisationStats(realisation, filterStudentFn, userHasAccessToAllStats)
+      )
       const summary = getSummaryStats(statistics, filterStudentFn, userHasAccessToAllStats)
 
       return {


### PR DESCRIPTION
On course statistics page, for any CourseStats-user, the following things are hidden:
- Population links
- Filtering by programme
- Faculty-stats
- Data on yearly basis, if there is less than 6 students

Additionally, Grades- and Student-tabs have switched places