### PR TITLE
Final fixes

### DIFF
--- a/services/backend/src/services/faculty/facultyGraduationTimes.js
+++ b/services/backend/src/services/faculty/facultyGraduationTimes.js
@@ -138,7 +138,11 @@ const getClassSizes = async (faculty, programmeCodes, since, classSizes, program
           level = 'bcMsCombo'
           actualStartdate = await findBachelorStartdate(studyrightid.replace(/-2$/, '-1'))
         } else {
-          level = 'master'
+          if (code.includes('KH')) {
+            level = 'bachelor' // Some rare faculties have one/two outliers with extent 2 for bachelor
+          } else {
+            level = 'master'
+          }
         }
       } else if (extentcode === 4) {
         level = 'doctor'

--- a/services/frontend/src/components/FacultyStatistics/BasicOverview/index.jsx
+++ b/services/frontend/src/components/FacultyStatistics/BasicOverview/index.jsx
@@ -359,7 +359,6 @@ const Overview = ({
                     )}
                     titles={thesisWriters?.data?.titles}
                     sliceStart={2}
-                    extraHeight="EXTRA HEIGHT"
                     yearsVisible={Array(thesisWriters?.data.tableStats.length).fill(false)}
                   />
                 </div>
@@ -408,7 +407,6 @@ const Overview = ({
                       )
                     )}
                     titles={credits?.data?.titles}
-                    extraHeight="EXTRA HEIGHT"
                     sliceStart={2}
                     yearsVisible={Array(credits?.data?.tableStats.length).fill(false)}
                     shortNames={creditShortTitles}

--- a/services/frontend/src/components/FacultyStatistics/InteractiveDataView/CollapsedStackedBar.jsx
+++ b/services/frontend/src/components/FacultyStatistics/InteractiveDataView/CollapsedStackedBar.jsx
@@ -5,13 +5,12 @@ import ReactHighcharts from 'react-highcharts'
 
 const colors = ['#7cb5ec', '#90ed7d', '#434348', '#f7a35c', '#FFF000', '#2b908f', '#f45b5b', '#91e8e1']
 
-const CollapsedStackedBar = ({ data, labels, longLabels, names, plotLinePlaces, differenceData, extraHeight }) => {
+const CollapsedStackedBar = ({ data, labels, longLabels, names, plotLinePlaces, differenceData }) => {
   const { getTextIn } = useLanguage()
   const transpose = matrix => {
     return matrix.reduce((prev, next) => next.map((_item, i) => (prev[i] || []).concat(next[i])), [])
   }
   if (names[0] === 'Started studying') names[0] += ' (new in faculty)'
-  const needsExtra = extraHeight === 'EXTRA HEIGHT'
   const dataTranspose = transpose(data)
     .map((obj, idx) => ({ name: names[idx], data: obj, color: colors[idx] }))
     .reverse()
@@ -56,15 +55,11 @@ const CollapsedStackedBar = ({ data, labels, longLabels, names, plotLinePlaces, 
     : []
 
   // Point width is 24 px different multipliers adjusts the height.
-  const getFlexHeight = (len, needsExtra) => {
-    if (len > 7 && needsExtra) return `${len * 24 * 1.5}px`
-    if (len > 5 && !needsExtra) return `${len * 24 * 1.5}px`
-    if (needsExtra && len <= 2) return `${len * 24 * 6}px`
-    if (needsExtra && len <= 4) return `${len * 24 * 3}px`
-    if (needsExtra) return `${len * 24 * 2}px`
-    if (len <= 2) return `${len * 24 * 5}px`
+  const getFlexHeight = len => {
+    if (len > 7) return `${len * 24 * 1.5}px`
+    if (len <= 2) return `${len * 24 * 6}px`
     if (len <= 4) return `${len * 24 * 3}px`
-    return `${len * 24}px`
+    return `${len * 24 * 2}px`
   }
 
   const getColor = change => {
@@ -78,7 +73,7 @@ const CollapsedStackedBar = ({ data, labels, longLabels, names, plotLinePlaces, 
     chart: {
       type: 'bar',
       marginTop: 60,
-      height: getFlexHeight(labels.length, needsExtra),
+      height: getFlexHeight(labels.length),
     },
     credits: {
       text: 'oodikone | TOSKA',

--- a/services/frontend/src/components/FacultyStatistics/InteractiveDataView/index.jsx
+++ b/services/frontend/src/components/FacultyStatistics/InteractiveDataView/index.jsx
@@ -12,7 +12,6 @@ const InteractiveDataTable = ({
   plotLinePlaces,
   titles,
   sliceStart,
-  extraHeight,
   yearsVisible,
   shortNames,
   studentsTable,
@@ -152,10 +151,20 @@ const InteractiveDataTable = ({
                   <CollapsedStackedBar
                     data={
                       sortbyColumn === 0
-                        ? sortedKeys?.map(programme => dataProgrammeStats[programme][yearIndex].slice(sliceStart))
-                        : keyOrder[yearIndex]?.map(programme =>
-                            dataProgrammeStats[programme][yearIndex].slice(sliceStart)
-                          )
+                        ? sortedKeys
+                            ?.map(programme =>
+                              dataProgrammeStats[programme]
+                                ? dataProgrammeStats[programme][yearIndex].slice(sliceStart)
+                                : null
+                            )
+                            .filter(prog => !!prog)
+                        : keyOrder[yearIndex]
+                            ?.map(programme =>
+                              dataProgrammeStats[programme]
+                                ? dataProgrammeStats[programme][yearIndex].slice(sliceStart)
+                                : null
+                            )
+                            .filter(prog => !!prog)
                     }
                     labels={sortbyColumn === 0 ? sortedKeys : keyOrder[yearIndex]}
                     plotLinePlaces={plotLinePlaces}
@@ -168,7 +177,6 @@ const InteractiveDataTable = ({
                     )}
                     longLabels={programmeNames}
                     names={titles?.slice(sliceStart)}
-                    extraHeight={extraHeight}
                     studentsTable={studentsTable}
                   />
                 </Table.Cell>


### PR DESCRIPTION
- I noticed that some rare faculties failed on update of graduation times on very specific few cases. There is fix for that and more explanation coming later on slack.
-  I noticed that due to changes charts in faculty view looked like shit. There was two option: add needs extra into rest of the cases or remove it in all cases -> I choose the last one
- Fix bug: toggle show all programmes, open year view (chart for programme) and toggle back to sowing only new programmes -> crash! I used also sorting when this happened, but I guess is chrashed also without doing it.