### PR TITLE
[Backend] Fix fix_faculty_code_constraint migration

### DIFF
--- a/updater/sis-updater-worker/src/db/migrations/20200310_00_fix_faculty_code_constraint.js
+++ b/updater/sis-updater-worker/src/db/migrations/20200310_00_fix_faculty_code_constraint.js
@@ -4,8 +4,9 @@ module.exports = {
     await queryInterface.addIndex('organization', ['code'], {
       unique: true,
     })
-    await queryInterface.addConstraint('studyright', ['faculty_code'], {
-      type: 'foreign key',
+    await queryInterface.addConstraint('studyright', {
+      fields: ['faculty_code'],
+      type: 'FOREIGN KEY',
       name: 'faculty_code_fk',
       references: {
         table: 'organization',


### PR DESCRIPTION
Noticed that one of the backend `sis-db` migrations was not working, probably due to some library update at some point in time, or something like this.