### PR TITLE
[FacultyProgrammeOverview] - Add toggle for `NEW_STUDY_PROGRAMMES` or `ALL_PROGRAMMES`

### DIFF
--- a/services/backend/src/routes/faculties.js
+++ b/services/backend/src/routes/faculties.js
@@ -112,7 +112,8 @@ router.get('/:id/progressstats', auth.roles(['facultyStatistics', 'katselmusView
   const code = req.params.id
   const specialGroups = req.query?.special_groups
   const graduated = req.query?.graduated
-  const programmes = await getProgrammes(code, 'NEW_STUDY_PROGRAMMES')
+  const programmeFilter = req.query?.programme_filter
+  const programmes = await getProgrammes(code, programmeFilter)
   if (!programmes) return res.status(422).end()
 
   if (!code) return res.status(422).end()

--- a/services/frontend/src/components/FacultyStatistics/FacultyProgrammeOverview/index.jsx
+++ b/services/frontend/src/components/FacultyStatistics/FacultyProgrammeOverview/index.jsx
@@ -97,14 +97,18 @@ export const FacultyProgrammeOverview = ({
   setGraduatedGroup,
   setSpecialGroups,
   specialGroups,
+  studyProgrammes,
+  setStudyProgrammes,
 }) => {
   const specials = specialGroups ? 'SPECIAL_EXCLUDED' : 'SPECIAL_INCLUDED'
   const graduated = graduatedGroup ? 'GRADUATED_EXCLUDED' : 'GRADUATED_INCLUDED'
+  const studyProgrammeFilter = studyProgrammes ? 'ALL_PROGRAMMES' : 'NEW_STUDY_PROGRAMMES'
   const { getTextIn } = useLanguage()
   const progressStats = useGetFacultyProgressStatsQuery({
     id: faculty?.code,
     specialGroups: specials,
     graduated,
+    studyProgrammeFilter,
   })
   const studentStats = useGetFacultyStudentStatsQuery({
     id: faculty.code,
@@ -181,6 +185,14 @@ export const FacultyProgrammeOverview = ({
           setValue={setGraduatedGroup}
           toolTips={facultyToolTips.GraduatedToggle}
           value={graduatedGroup}
+        />
+        <Toggle
+          cypress="ProgrammeToggle"
+          firstLabel="New study programmes"
+          secondLabel="All study programmes"
+          setValue={setStudyProgrammes}
+          toolTips={facultyToolTips.ProgrammeToggle}
+          value={studyProgrammes}
         />
       </div>
       {isFetchingOrLoading ? (

--- a/services/frontend/src/components/FacultyStatistics/index.jsx
+++ b/services/frontend/src/components/FacultyStatistics/index.jsx
@@ -66,7 +66,9 @@ export const FacultyStatistics = () => {
             requiredRights={requiredRights}
             setGraduatedGroup={setGraduatedGroup}
             setSpecialGroups={setSpecialGroups}
+            setStudyProgrammes={setStudyProgrammes}
             specialGroups={specialGroups}
+            studyProgrammes={studyProgrammes}
           />
         ),
       },

--- a/services/frontend/src/redux/facultyStats.js
+++ b/services/frontend/src/redux/facultyStats.js
@@ -23,8 +23,8 @@ const facultystatsApi = RTKApi.injectEndpoints({
         `/faculties/${id}/graduationtimes?programme_filter=${studyProgrammeFilter}`,
     }),
     getFacultyProgressStats: builder.query({
-      query: ({ id, specialGroups, graduated }) =>
-        `/faculties/${id}/progressstats?special_groups=${specialGroups}&graduated=${graduated}`,
+      query: ({ id, specialGroups, graduated, studyProgrammeFilter }) =>
+        `/faculties/${id}/progressstats?special_groups=${specialGroups}&graduated=${graduated}&programme_filter=${studyProgrammeFilter}`,
     }),
     getAllFacultiesProgressStats: builder.query({
       query: ({ graduated, includeSpecials }) =>


### PR DESCRIPTION
`FacultyProgrammeOverview` had hard coded `NEW_STUDY_PROGRAMMES` filter for fetching programmes, added a similar toggle from the basic stats view, so that the data can be controller in a similar manner