### PR TITLE
[Backend] Make H50 configurable

### DIFF
--- a/services/backend/config/facultyCodes.js
+++ b/services/backend/config/facultyCodes.js
@@ -18,6 +18,9 @@ const facultyCodes = [
   'Y01',
 ]
 
+const magic_faculty_code = 'H50'
+
 module.exports = {
   facultyCodes,
+  magic_faculty_code,
 }

--- a/services/backend/src/routes/university.js
+++ b/services/backend/src/routes/university.js
@@ -1,5 +1,7 @@
 const router = require('express').Router()
 
+const { magic_faculty_code } = require('../../config/facultyCodes')
+const { serviceProvider } = require('../conf-backend')
 const { getFacultyList } = require('../services/faculty/facultyHelpers')
 const { getFacultyProgressStats, getGraduationStats } = require('../services/faculty/facultyService')
 const { getMedian } = require('../services/studyprogramme/studyprogrammeHelpers')
@@ -22,11 +24,11 @@ router.get('/allprogressstats', async (req, res) => {
   }
 
   const universityData = {
-    years: codeToData.H50.years,
-    yearlyBachelorTitles: codeToData.H50.yearlyBachelorTitles,
-    yearlyBcMsTitles: codeToData.H50.yearlyBcMsTitles,
-    yearlyMasterTitles: codeToData.H50.yearlyMasterTitles,
-    yearlyLicentiateTitles: codeToData.H50.yearlyLicentiateTitles,
+    years: codeToData[magic_faculty_code].years,
+    yearlyBachelorTitles: codeToData[magic_faculty_code].yearlyBachelorTitles,
+    yearlyBcMsTitles: codeToData[magic_faculty_code].yearlyBcMsTitles,
+    yearlyMasterTitles: codeToData[magic_faculty_code].yearlyMasterTitles,
+    yearlyLicentiateTitles: codeToData[magic_faculty_code].yearlyLicentiateTitles,
     programmeNames: allFaculties.reduce((obj, faculty) => {
       const { name, ...rest } = faculty.dataValues
       obj[faculty.code] = { ...rest, ...name }
@@ -90,8 +92,9 @@ router.get('/allgraduationstats', async (_req, res) => {
   const facultyCodes = allFaculties.map(faculty => faculty.code)
   const facultyData = {}
   const timesArrays = [] // keep book of these to null them in the end, large lists not used in frontend
+  const programmeFilter = serviceProvider === 'Toska' ? 'NEW_STUDY_PROGRAMME' : 'ALL_PROGRAMMES'
   for (const facultyCode of facultyCodes) {
-    const data = await getGraduationStats(facultyCode, 'NEW_STUDY_PROGRAMMES', true)
+    const data = await getGraduationStats(facultyCode, programmeFilter, true)
     if (!data) return res.status(500).json({ message: `Did not find data for ${facultyCode}` })
     facultyData[facultyCode] = data
   }


### PR DESCRIPTION
University view would ever so slightly blow up if a `H50` organization/faculty didn't exist, so made it configurable through the same place as facultyCodes.
Retained old default value.
Also changed `/allgraduationstats` to use `ALL_PROGRAMMES` when serviceProvider is not `Toska`