### PR TITLE
[Backend] Change representation of bigint columns to strings in TypeScript

### DIFF
--- a/services/backend/src/models/kone/customPopulationSearch.ts
+++ b/services/backend/src/models/kone/customPopulationSearch.ts
@@ -13,10 +13,10 @@ export class CustomPopulationSearch extends Model<
   @PrimaryKey
   @AutoIncrement
   @Column(DataType.BIGINT)
-  id!: CreationOptional<bigint>
+  id!: CreationOptional<string>
 
   @Column(DataType.BIGINT)
-  userId!: bigint
+  userId!: string
 
   @Column(DataType.STRING)
   name!: string

--- a/services/backend/src/models/kone/openUniPopulationSearch.ts
+++ b/services/backend/src/models/kone/openUniPopulationSearch.ts
@@ -14,10 +14,10 @@ export class OpenUniPopulationSearch extends Model<
   @PrimaryKey
   @AutoIncrement
   @Column(DataType.BIGINT)
-  id!: CreationOptional<bigint>
+  id!: CreationOptional<string>
 
   @Column(DataType.BIGINT)
-  userId!: bigint
+  userId!: string
 
   @Column(DataType.STRING)
   name!: string

--- a/services/backend/src/models/kone/studyGuidanceGroupTag.ts
+++ b/services/backend/src/models/kone/studyGuidanceGroupTag.ts
@@ -11,7 +11,7 @@ export class StudyGuidanceGroupTag extends Model<InferAttributes<StudyGuidanceGr
   @PrimaryKey
   @AutoIncrement
   @Column(DataType.BIGINT)
-  id!: bigint
+  id!: string
 
   @Unique
   @Column(DataType.STRING)

--- a/services/backend/src/models/kone/tag.ts
+++ b/services/backend/src/models/kone/tag.ts
@@ -13,7 +13,7 @@ export class Tag extends Model<InferAttributes<Tag>> {
   @AutoIncrement
   @ForeignKey(() => TagStudent)
   @Column(DataType.BIGINT)
-  tag_id!: bigint
+  tag_id!: string
 
   @BelongsTo(() => TagStudent)
   tagStudent!: TagStudent
@@ -28,5 +28,5 @@ export class Tag extends Model<InferAttributes<Tag>> {
   year!: string
 
   @Column(DataType.BIGINT)
-  personal_user_id!: bigint
+  personal_user_id!: string
 }

--- a/services/backend/src/models/kone/tagStudent.ts
+++ b/services/backend/src/models/kone/tagStudent.ts
@@ -14,7 +14,7 @@ export class TagStudent extends Model<InferAttributes<TagStudent>> {
   @AutoIncrement
   @ForeignKey(() => Tag)
   @Column(DataType.BIGINT)
-  tag_id!: bigint
+  tag_id!: string
 
   @PrimaryKey
   @ForeignKey(() => Student)

--- a/services/backend/src/models/user.ts
+++ b/services/backend/src/models/user.ts
@@ -14,7 +14,7 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
   @PrimaryKey
   @AutoIncrement
   @Column(DataType.BIGINT)
-  id!: CreationOptional<bigint>
+  id!: CreationOptional<string>
 
   @Column(DataType.STRING)
   fullName!: string

--- a/services/backend/src/routes/completedCoursesSearch.ts
+++ b/services/backend/src/routes/completedCoursesSearch.ts
@@ -88,7 +88,7 @@ router.post('/searches', async (req: OodikoneRequest, res) => {
 })
 
 router.put('/searches/:id', async (req: OodikoneRequest, res) => {
-  const id = BigInt(req.params?.id)
+  const id = req.params?.id
   const courseCodes = req.body?.courselist || []
   const userId = req.user!.id
   if (!id || !userId) {
@@ -113,7 +113,7 @@ router.delete('/searches/:id', async (req: OodikoneRequest, res) => {
   if (!id || !userId) {
     return res.status(422).end()
   }
-  const deletedSearch = await deleteSearch(userId, BigInt(id))
+  const deletedSearch = await deleteSearch(userId, id)
   if (!deletedSearch) {
     return res.status(404).json({ error: 'Courselist could not be found' })
   }

--- a/services/backend/src/routes/customOpenUniSearch.ts
+++ b/services/backend/src/routes/customOpenUniSearch.ts
@@ -53,7 +53,7 @@ router.post('/searches', async (req: OodikoneRequest, res) => {
 })
 
 router.put('/searches/:id', async (req: OodikoneRequest, res) => {
-  const id = BigInt(req.params?.id)
+  const id = req.params?.id
   const courseCodes = req.body?.courselist || []
   const userId = req.user!.id
   if (!id || !userId) {
@@ -73,7 +73,7 @@ router.put('/searches/:id', async (req: OodikoneRequest, res) => {
 })
 
 router.delete('/searches/:id', async (req: OodikoneRequest, res) => {
-  const id = BigInt(req.params?.id)
+  const id = req.params?.id
   const userId = req.user!.id
   if (!id || !userId) {
     return res.status(422).end()

--- a/services/backend/src/routes/customPopulationSearch.ts
+++ b/services/backend/src/routes/customPopulationSearch.ts
@@ -11,7 +11,7 @@ import { OodikoneRequest } from '../types'
 const router = Router()
 
 router.get('/', async (req: OodikoneRequest, res) => {
-  const id = req.user!.id as unknown as bigint
+  const { id } = req.user!
   const customPopulationSearches = await getCustomPopulationSearchesByUser(id)
   res.json(customPopulationSearches)
 })
@@ -29,7 +29,7 @@ router.post('/', async (req: OodikoneRequest, res) => {
     return res.status(400).json({ error: 'Students must be of type array' })
   }
 
-  const id = user!.id as unknown as bigint
+  const { id } = user!
   const customPopulationSearch = await createCustomPopulationSearch(name, id, students || [])
   res.json(customPopulationSearch)
 })
@@ -38,8 +38,8 @@ router.put('/:id', async (req: OodikoneRequest, res) => {
   const {
     body: { students },
   } = req
-  const id = req.params.id as unknown as bigint
-  const userId = req.user!.id as unknown as bigint
+  const { id } = req.params
+  const userId = req.user!.id
 
   if (!id) {
     return res.status(400).json({ error: 'Id missing' })
@@ -60,8 +60,8 @@ router.put('/:id', async (req: OodikoneRequest, res) => {
 })
 
 router.delete('/:id', async (req: OodikoneRequest, res) => {
-  const id = req.params.id as unknown as bigint
-  const userId = req.user!.id as unknown as bigint
+  const { id } = req.params
+  const userId = req.user!.id
 
   if (!id) {
     return res.status(400).json({ error: 'Id missing' })

--- a/services/backend/src/services/customPopulationSearch.ts
+++ b/services/backend/src/services/customPopulationSearch.ts
@@ -1,6 +1,6 @@
 import { CustomPopulationSearch } from '../models/kone'
 
-export const getCustomPopulationSearchesByUser = async (userId: bigint) => {
+export const getCustomPopulationSearchesByUser = async (userId: string) => {
   return CustomPopulationSearch.findAll({
     where: {
       userId,
@@ -8,7 +8,7 @@ export const getCustomPopulationSearchesByUser = async (userId: bigint) => {
   })
 }
 
-export const createCustomPopulationSearch = async (name: string, userId: bigint, students: string[]) => {
+export const createCustomPopulationSearch = async (name: string, userId: string, students: string[]) => {
   return CustomPopulationSearch.create({
     name,
     userId,
@@ -16,7 +16,7 @@ export const createCustomPopulationSearch = async (name: string, userId: bigint,
   })
 }
 
-export const updateCustomPopulationSearch = async (userId: bigint, id: bigint, students: string[]) => {
+export const updateCustomPopulationSearch = async (userId: string, id: string, students: string[]) => {
   const targetCustomPopulationSearch = await CustomPopulationSearch.findOne({
     where: {
       id,
@@ -33,7 +33,7 @@ export const updateCustomPopulationSearch = async (userId: bigint, id: bigint, s
   })
 }
 
-export const deleteCustomPopulationSearch = async (userId: bigint, id: bigint) => {
+export const deleteCustomPopulationSearch = async (userId: string, id: string) => {
   return CustomPopulationSearch.destroy({
     where: {
       id,

--- a/services/backend/src/services/openUni/openUniManageSearches.ts
+++ b/services/backend/src/services/openUni/openUniManageSearches.ts
@@ -7,14 +7,14 @@ import {
 } from './openUniSearches'
 
 type FoundSearch = {
-  id: bigint
-  userId: bigint
+  id: string
+  userId: string
   name: string
   courseList: string[]
   updatedAt: Date
 }
 
-export const getOpenUniSearches = async (userId: bigint) => {
+export const getOpenUniSearches = async (userId: string) => {
   const savedSearches = await getOpenUniSearchesByUser(userId)
   if (savedSearches === undefined) {
     return []
@@ -34,7 +34,7 @@ export const getOpenUniSearches = async (userId: bigint) => {
   return foundSearches
 }
 
-export const createNewSearch = async (userId: bigint, name: string, courseCodes: string[]) => {
+export const createNewSearch = async (userId: string, name: string, courseCodes: string[]) => {
   const savedSearches = await getOpenUniSearchesByUser(userId)
   if (savedSearches && savedSearches.some(search => search.name === name)) {
     return null
@@ -51,7 +51,7 @@ export const createNewSearch = async (userId: bigint, name: string, courseCodes:
   }
 }
 
-export const deleteSearch = async (userId: bigint, id: bigint) => {
+export const deleteSearch = async (userId: string, id: string) => {
   try {
     const deleted = await deleteOpenUniSearch(userId, id)
     if (!deleted) {
@@ -64,7 +64,7 @@ export const deleteSearch = async (userId: bigint, id: bigint) => {
   }
 }
 
-export const updateSearch = async (userId: bigint, id: bigint, courseCodes: string[]) => {
+export const updateSearch = async (userId: string, id: string, courseCodes: string[]) => {
   try {
     const updated = await updateOpenUniPopulationSearch(userId, id, courseCodes)
     if (!updated) {

--- a/services/backend/src/services/openUni/openUniSearches.ts
+++ b/services/backend/src/services/openUni/openUniSearches.ts
@@ -88,7 +88,7 @@ export const getStudyRights = async (studentNumbers: string[]) => {
   })
 }
 
-export const getOpenUniSearchesByUser = async (userId: bigint) => {
+export const getOpenUniSearchesByUser = async (userId: string) => {
   return await OpenUniPopulationSearch.findAll({
     where: {
       userId,
@@ -96,7 +96,7 @@ export const getOpenUniSearchesByUser = async (userId: bigint) => {
   })
 }
 
-export const createOpenUniPopulationSearch = async (userId: bigint, name: string, courseCodes: string[]) => {
+export const createOpenUniPopulationSearch = async (userId: string, name: string, courseCodes: string[]) => {
   return await OpenUniPopulationSearch.create({
     userId,
     name,
@@ -104,7 +104,7 @@ export const createOpenUniPopulationSearch = async (userId: bigint, name: string
   })
 }
 
-export const updateOpenUniPopulationSearch = async (userId: bigint, id: bigint, courseCodes: string[]) => {
+export const updateOpenUniPopulationSearch = async (userId: string, id: string, courseCodes: string[]) => {
   const searchToUpdate = await OpenUniPopulationSearch.findOne({
     where: {
       userId,
@@ -119,7 +119,7 @@ export const updateOpenUniPopulationSearch = async (userId: bigint, id: bigint, 
   return await searchToUpdate.update({ courseCodes })
 }
 
-export const deleteOpenUniSearch = async (userId: bigint, id: bigint) => {
+export const deleteOpenUniSearch = async (userId: string, id: string) => {
   return await OpenUniPopulationSearch.destroy({
     where: {
       userId,

--- a/services/backend/src/services/userService.ts
+++ b/services/backend/src/services/userService.ts
@@ -43,7 +43,7 @@ export const modifyAccess = async (username: string, rolesOfUser: Record<string,
   userDataCache.delete(username)
 }
 
-export const modifyElementDetails = async (id: bigint, codes: string[], enable: boolean) => {
+export const modifyElementDetails = async (id: string, codes: string[], enable: boolean) => {
   const user = await User.findOne({ where: { id } })
   if (!user) {
     throw new Error(`User with id ${id} not found`)
@@ -192,7 +192,7 @@ export const findAll = async () => {
   return formattedUsers.sort(createLocaleComparator('name'))
 }
 
-export const findOne = async (id: bigint) => {
+export const findOne = async (id: string) => {
   const user = (await User.findOne({ where: { id } }))?.toJSON()
   if (!user) {
     throw new Error(`User with id ${id} not found`)

--- a/services/backend/src/types/user.ts
+++ b/services/backend/src/types/user.ts
@@ -13,7 +13,7 @@ export type ExpandedUser = InferAttributes<User> & {
 }
 
 export type FormattedUser = {
-  id: bigint
+  id: string
   userId: string
   username: string
   name: string


### PR DESCRIPTION
Sequelize automatically converts all bigints in the db into strings so they should be treated as such in our code.