### PR TITLE
OOD-59: [updater] [backend] try-catch-clauses for updates and if-clauses for using HY-specific programmeCode-map

### DIFF
--- a/services/backend/src/services/faculty/faculty.ts
+++ b/services/backend/src/services/faculty/faculty.ts
@@ -2,6 +2,7 @@ import { groupBy, orderBy } from 'lodash'
 import moment from 'moment'
 import { InferAttributes, QueryTypes } from 'sequelize'
 
+import { serviceProvider } from '../../config'
 import { programmeCodes } from '../../config/programmeCodes'
 import { dbConnections } from '../../database/connection'
 import { Organization, ProgrammeModule } from '../../models'
@@ -54,7 +55,9 @@ export const getDegreeProgrammesOfOrganization = async (organizationId: string, 
   const programmesWithProgIds = programmesOfOrganization.map(programme => ({
     ...programme,
     progId:
-      programme.code in programmeCodes ? programmeCodes[programme.code as keyof typeof programmeCodes] : programme.code,
+      programme.code in programmeCodes && serviceProvider !== 'fd'
+        ? programmeCodes[programme.code as keyof typeof programmeCodes]
+        : programme.code,
   }))
   const programmesGroupedByCode = groupBy(orderBy(programmesWithProgIds, ['valid_from'], ['desc']), prog => prog.code)
   const curriculumPeriods = await getCurriculumPeriods()

--- a/services/backend/src/services/studyProgramme/studyProgrammeHelpers.ts
+++ b/services/backend/src/services/studyProgramme/studyProgrammeHelpers.ts
@@ -165,8 +165,10 @@ export const tableTitles = {
   studytracksEnd: ['Men', 'Women', 'Other/\nUnknown', 'Finland', 'Other'],
 } as const
 
-export const getId = (code: string) =>
-  code in programmeCodes ? programmeCodes[code as keyof typeof programmeCodes] : ''
+export const getId = (code: string) => {
+  if (serviceProvider !== 'fd') return code in programmeCodes ? programmeCodes[code as keyof typeof programmeCodes] : ''
+  return code
+}
 
 export const getGoal = (programme?: string) => {
   if (!programme) return 0

--- a/updater/sis-updater-worker/src/updater/updateProgrammeModules/resolver.js
+++ b/updater/sis-updater-worker/src/updater/updateProgrammeModules/resolver.js
@@ -1,3 +1,5 @@
+const { serviceProvider } = require('../../config')
+
 const anyModule = rule => ({ id: rule.localId, name: 'Any module' })
 const anyCourse = rule => ({ id: rule.localId, name: 'Any course' })
 const unknownRule = rule => ({ type: rule.type, fact: 'Unhandled rule' })
@@ -73,7 +75,7 @@ class ModuleResolver {
     const children = []
 
     for (const mod of modules) {
-      if (mod.code?.startsWith('KK-')) continue
+      if (serviceProvider !== 'fd' && mod.code?.startsWith('KK-')) continue
       let result = this.moduleCache[mod.id]
       if (!result) {
         result = await this.resolveSingleModule(mod)

--- a/updater/sis-updater-worker/src/updater/updateProgrammeModules/updateProgrammeModules.js
+++ b/updater/sis-updater-worker/src/updater/updateProgrammeModules/updateProgrammeModules.js
@@ -3,6 +3,7 @@ const { chunk } = require('lodash')
 const { bulkCreate, selectFromByIds } = require('../../db')
 const { dbConnections } = require('../../db/connection')
 const { ProgrammeModule, ProgrammeModuleChild } = require('../../db/models')
+const { logger } = require('../../utils/logger')
 const ModuleResolver = require('./resolver')
 
 const resolveProgramme = async programme => {
@@ -56,7 +57,14 @@ const recursiveWrite = (modArg, parentId, programmeMap, joinMap) => {
   if (parentId) joinMap[join.composite] = join
 
   if (!children) return
-  children.forEach(child => recursiveWrite(child, mod.id, programmeMap, joinMap))
+  try {
+    children.forEach(child => recursiveWrite(child, mod.id, programmeMap, joinMap))
+  } catch (error) {
+    logger.error(
+      `Could not update programme module with id ${mod.id} and parentId ${parentId} due to faulty children/rule handling`,
+      error
+    )
+  }
 }
 
 const updateProgrammeModulesChunk = async programmeIds => {


### PR DESCRIPTION
Updater is failing on at least studyRights, courses and programmeModules, so instead of letting the run crash entirely, we add try clauses and logging to catch the specific problematic entities.

Also, FD should not use the programmeCode-map with HY-codes in the backend. So it is if-claused away.