### PR TITLE
OOD-68: [backend] continue if study right does not have a student

### DIFF
--- a/services/backend/src/services/studyProgramme/studyTrackStats.ts
+++ b/services/backend/src/services/studyProgramme/studyTrackStats.ts
@@ -345,6 +345,7 @@ const getMainStatsByTrackAndYear = async (
 
   for (const studyRight of studyRightsOfProgramme) {
     if (!studyRight.semesterEnrollments) continue
+    if (!studyRight.student) continue
     const studyRightElement = studyRight.studyRightElements.find(element => element.code === studyProgramme)
     if (!studyRightElement) continue
     if (!includeGraduated && studyRightElement.graduated) {

--- a/services/backend/src/services/studyProgramme/studyTrackStats.ts
+++ b/services/backend/src/services/studyProgramme/studyTrackStats.ts
@@ -344,8 +344,7 @@ const getMainStatsByTrackAndYear = async (
     : {}
 
   for (const studyRight of studyRightsOfProgramme) {
-    if (!studyRight.semesterEnrollments) continue
-    if (!studyRight.student) continue
+    if (!studyRight.semesterEnrollments || !studyRight.student) continue
     const studyRightElement = studyRight.studyRightElements.find(element => element.code === studyProgramme)
     if (!studyRightElement) continue
     if (!includeGraduated && studyRightElement.graduated) {


### PR DESCRIPTION
Faculty stats are failing because of study rights not having students (silly study rights, indeed!), so this would need a null check.