### PR TITLE
[Frontend] Added max-old-space-size to package.json build

### DIFF
--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && NODE_OPTIONS=\"--max-old-space-size=4096\" vite build",
     "preview": "vite preview",
     "tsc": "tsc"
   },


### PR DESCRIPTION
Added `NODE_OPTIONS="--max-old-space-size=4096"` in frontend package.json to resolve our CI / CD build broken