### PR TITLE
OOD-88: check for default service provider before disabling role alternatives

### DIFF
--- a/services/frontend/src/pages/Users/UserPage/RolesCard.tsx
+++ b/services/frontend/src/pages/Users/UserPage/RolesCard.tsx
@@ -1,6 +1,7 @@
 import { Box, Card, CardContent, Checkbox, Chip, Stack } from '@mui/material'
 import { useEffect, useState } from 'react'
 
+import { isDefaultServiceProvider } from '@/common'
 import { RoleChip } from '@/components/material/RoleChip'
 import { useStatusNotification } from '@/components/material/StatusNotificationContext'
 import { useGetRolesQuery, useModifyRolesMutation } from '@/redux/users'
@@ -65,7 +66,7 @@ export const RolesCard = ({ user }: { user: User }) => {
                 <Checkbox
                   checked={selected.includes(role)}
                   color="success"
-                  disabled={!editing || !['admin', 'teachers'].includes(role)}
+                  disabled={!editing || !['admin', 'teachers'].includes(role) && isDefaultServiceProvider()}
                   onChange={() => toggleRole(role)}
                 />
               </Stack>


### PR DESCRIPTION
At some point role alternatives have been disabled on the user editing page, and this is not a wanted feature for users in the FD-environment. Added checking for default (i.e., HY/Toska) user before disabling check boxes.