### PR TITLE
OOD-84: using try catch logic when inserting programme module children [UPDATER-WORKER]

### DIFF
--- a/updater/sis-updater-worker/src/db/index.js
+++ b/updater/sis-updater-worker/src/db/index.js
@@ -56,9 +56,9 @@ const bulkCreate = async (
   findBy = 'id'
 ) => {
   try {
-    let options
-    if (upsertStyle) options = { updateOnDuplicate: getColumnsToUpdate(model, properties), transaction }
-    else options = { ignoreDuplicates: true, transaction }
+    const options = upsertStyle
+      ? { updateOnDuplicate: getColumnsToUpdate(model, properties), transaction }
+      : { ignoreDuplicates: true, transaction }
     await model.bulkCreate(entities, options)
   } catch (error) {
     for (const entity of entities) {

--- a/updater/sis-updater-worker/src/updater/updateProgrammeModules/updateProgrammeModules.js
+++ b/updater/sis-updater-worker/src/updater/updateProgrammeModules/updateProgrammeModules.js
@@ -81,7 +81,7 @@ const updateProgrammeModulesChunk = async programmeIds => {
   }
 
   await bulkCreate(ProgrammeModule, Object.values(moduleMap))
-  await bulkCreate(ProgrammeModuleChild, Object.values(joinMap), null, [], false)
+  await bulkCreate(ProgrammeModuleChild, Object.values(joinMap), null, [], false, 'composite')
 }
 
 const updateProgrammeModules = async programmeIds => {

--- a/updater/sis-updater-worker/src/updater/updateProgrammeModules/updateProgrammeModules.js
+++ b/updater/sis-updater-worker/src/updater/updateProgrammeModules/updateProgrammeModules.js
@@ -81,7 +81,7 @@ const updateProgrammeModulesChunk = async programmeIds => {
   }
 
   await bulkCreate(ProgrammeModule, Object.values(moduleMap))
-  await ProgrammeModuleChild.bulkCreate(Object.values(joinMap), { ignoreDuplicates: true })
+  await bulkCreate(ProgrammeModuleChild, Object.values(joinMap), null, [], false)
 }
 
 const updateProgrammeModules = async programmeIds => {


### PR DESCRIPTION
Migrating programme modules from Sisu to Oodikone is failing in some environments, due to the bulk create for programme module children not being try/catched and falling back to inserting those that do not fail. In this solution, the bulkCreate -function gets a new parameter (upsertStyle) which is set to true per default, but if it is set to false, the bulkCreate tries a bulkCreate with ignoreDuplicates, and if it fails, it falls back to looping through the entities and findOrCreating them one by one.