### PR TITLE
[FRONTEND] runtime configurable sisurl

### DIFF
--- a/services/frontend/index.html
+++ b/services/frontend/index.html
@@ -12,6 +12,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script src="/runtime-frontend-config.js"></script>
     <script type="module" src="src/main.jsx"></script>
   </body>
 </html>

--- a/services/frontend/public/runtime-frontend-config.js
+++ b/services/frontend/public/runtime-frontend-config.js
@@ -1,0 +1,4 @@
+// In this file one can define variables to be used globally at runtime
+
+// eslint-disable-next-line import/no-unused-modules, @typescript-eslint/no-unused-vars
+const frontendRuntimeConfiguredSisUrl = 'https://sis-qa.funidata.fi'

--- a/services/frontend/src/components/common/SisuLinkItem.tsx
+++ b/services/frontend/src/components/common/SisuLinkItem.tsx
@@ -1,13 +1,16 @@
 import { Icon, Item } from 'semantic-ui-react'
-import { sisUrl } from '@/conf'
+import { sisUrl, serviceProvider } from '@/conf'
 
 interface SisuLinkItemProps {
   id: string
 }
 
+//@ts-expect-error since frontendRuntimeConfiguredSisUrl is defined in a separate, possibly mounted js-file
+const usableSisUrl = serviceProvider === 'fd' ? frontendRuntimeConfiguredSisUrl : sisUrl
+
 export const SisuLinkItem = ({ id }: SisuLinkItemProps) => (
   <div data-cy="sisulink">
-    <Item as="a" href={`${sisUrl}/tutor/role/staff/student/${id}/basic/basic-info`} target="_blank">
+    <Item as="a" href={`${usableSisUrl}/tutor/role/staff/student/${id}/basic/basic-info`} target="_blank">
       <Icon name="external alternate" />
       Sisu
     </Item>

--- a/services/frontend/src/components/material/StudentInfoItem.tsx
+++ b/services/frontend/src/components/material/StudentInfoItem.tsx
@@ -4,8 +4,11 @@ import Stack from '@mui/material/Stack'
 
 import { Link } from 'react-router'
 
-import { sisUrl } from '@/conf'
+import { sisUrl, serviceProvider } from '@/conf'
 import { ExternalLink } from './ExternalLink'
+
+//@ts-expect-error since frontendRuntimeConfiguredSisUrl is defined in a separate, possibly mounted js-file
+const usableSisUrl = serviceProvider === 'fd' ? frontendRuntimeConfiguredSisUrl : sisUrl
 
 export const StudentInfoItem = ({ sisPersonId, studentNumber }: { sisPersonId: string; studentNumber: string }) => (
   <Stack direction="row" justifyContent="space-between">
@@ -14,7 +17,7 @@ export const StudentInfoItem = ({ sisPersonId, studentNumber }: { sisPersonId: s
       <IconButton component={Link} sx={{ padding: 0 }} target="_blank" to={`/students/${studentNumber}`}>
         <PersonIcon color="primary" fontSize="small" />
       </IconButton>
-      <ExternalLink href={`${sisUrl}/tutor/role/staff/student/${sisPersonId}/basic/basic-info`} text="Sisu" />
+      <ExternalLink href={`${usableSisUrl}/tutor/role/staff/student/${sisPersonId}/basic/basic-info`} text="Sisu" />
     </Stack>
   </Stack>
 )

--- a/services/frontend/src/pages/Students/StudentDetails/StudentInfoCard.tsx
+++ b/services/frontend/src/pages/Students/StudentDetails/StudentInfoCard.tsx
@@ -9,11 +9,14 @@ import Typography from '@mui/material/Typography'
 import { callApi } from '@/apiConnection'
 import { ExternalLink } from '@/components/material/ExternalLink'
 import { useStudentNameVisibility } from '@/components/material/StudentNameVisibilityToggle'
-import { sisUrl } from '@/conf'
+import { sisUrl, serviceProvider } from '@/conf'
 import { DateFormat } from '@/constants/date'
 import { useGetAuthorizedUserQuery } from '@/redux/auth'
 import { reformatDate } from '@/util/timeAndDate'
 import { EnrollmentAccordion } from './EnrollmentAccordion'
+
+//@ts-expect-error since frontendRuntimeConfiguredSisUrl is defined in a separate, possibly mounted js-file
+const usableSisUrl = serviceProvider === 'fd' ? frontendRuntimeConfiguredSisUrl : sisUrl
 
 export const StudentInfoCard = ({ student }) => {
   const { visible: showName } = useStudentNameVisibility()
@@ -40,7 +43,7 @@ export const StudentInfoCard = ({ student }) => {
             </Typography>
             <ExternalLink
               cypress="sisu-link"
-              href={`${sisUrl}/tutor/role/staff/student/${student.sis_person_id}/basic/basic-info`}
+              href={`${usableSisUrl}/tutor/role/staff/student/${student.sis_person_id}/basic/basic-info`}
               text="Sisu"
               variant="h6"
             />


### PR DESCRIPTION
In the Funidata environment we need to be able to configure the sis url at runtime, as we use the same already built react-image for different sisu-users.